### PR TITLE
Fix path binding in menu container

### DIFF
--- a/NexStock1.0/View/AppView.swift
+++ b/NexStock1.0/View/AppView.swift
@@ -26,7 +26,8 @@ struct AppView: View {
                             content: {
                                 InventoryScreenView(path: $path)
                             },
-                            showMenu: $showMenu // ✅ YA FUNCIONA
+                            path: $path,
+                            showMenu: $showMenu
                         )
                     case .userManagement:
                         UserManagementView()

--- a/NexStock1.0/View/MenuContainerView.swift
+++ b/NexStock1.0/View/MenuContainerView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct MenuContainerView<Content: View>: View {
     @ViewBuilder var content: () -> Content
-    @State private var path = NavigationPath()
+    @Binding var path: NavigationPath
     @Binding var showMenu: Bool
     
     var body: some View {


### PR DESCRIPTION
## Summary
- pass the navigation path into `MenuContainerView`
- bind the path when showing the inventory screen so the side menu navigates correctly

## Testing
- `swift --version`
- `swiftlint version` *(fails: command not found)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560cc608608327a390c3c3e30b2251