### PR TITLE
Move settings to side menu and implement logout

### DIFF
--- a/NexStock1.0/Services/AuthService.swift
+++ b/NexStock1.0/Services/AuthService.swift
@@ -61,5 +61,6 @@ class AuthService: ObservableObject {
 
     func logout() {
         token = nil
+        UserDefaults.standard.removeObject(forKey: "authToken")
     }
 }

--- a/NexStock1.0/View/HeaderView.swift
+++ b/NexStock1.0/View/HeaderView.swift
@@ -13,6 +13,7 @@ struct HeaderView: View {
     @State private var showUsername = true
     @Environment(\.sizeCategory) var sizeCategory
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var authService: AuthService
 
     var body: some View {
         HStack {
@@ -54,11 +55,9 @@ struct HeaderView: View {
 
             // Menú con bola roja escalable
             Menu {
-                Button("settings".localized) {
-                    path.append(AppRoute.settings)
-                }
                 Button("logout".localized) {
-                    print("Cerrar sesión")
+                    authService.logout()
+                    path.removeLast(path.count)
                 }
             } label: {
                 Circle()

--- a/NexStock1.0/View/SideMenuView.swift
+++ b/NexStock1.0/View/SideMenuView.swift
@@ -140,6 +140,18 @@ struct SideMenuView: View {
                         .padding(.leading, 12)
                     }
 
+                    // Configuración
+                    Button {
+                        path.append(AppRoute.settings)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "gearshape.fill")
+                            Text("settings".localized)
+                        }
+                    }
+                    .font(.title3.bold())
+                    .foregroundColor(.fourthColor)
+
                     Spacer()
                 }
                 .padding(.top, topSafeArea + 16)


### PR DESCRIPTION
## Summary
- add a gear shaped Settings button to the side menu
- keep the header menu only for logging out
- clear the saved token when logging out

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6856d342359c8327b34796602b700a98