### PR TITLE
Fix system config auth and dynamic logo

### DIFF
--- a/NexStock1.0/Services/AuthService.swift
+++ b/NexStock1.0/Services/AuthService.swift
@@ -22,6 +22,7 @@ class AuthService: ObservableObject {
     static let shared = AuthService()
     
     @Published var token: String? = nil
+    @Published var logoURL: String? = nil
 
     var isAuthenticated: Bool {
         return token != nil

--- a/NexStock1.0/View/HeaderView.swift
+++ b/NexStock1.0/View/HeaderView.swift
@@ -53,17 +53,30 @@ struct HeaderView: View {
 
             Spacer()
 
-            // Menú con bola roja escalable
+            // Menú con logo dinámico
             Menu {
                 Button("logout".localized) {
                     authService.logout()
                     path.removeLast(path.count)
                 }
             } label: {
-                Circle()
-                    .fill(Color.red)
+                if let urlString = authService.logoURL, let url = URL(string: urlString) {
+                    AsyncImage(url: url) { phase in
+                        if let img = phase.image {
+                            img.resizable()
+                        } else {
+                            ProgressView()
+                        }
+                    }
                     .frame(width: iconSize, height: iconSize)
+                    .clipShape(Circle())
                     .shadow(radius: 1)
+                } else {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: iconSize, height: iconSize)
+                        .shadow(radius: 1)
+                }
             }
         }
         .padding(.horizontal)

--- a/NexStock1.0/ViewModels/LoginViewModel.swift
+++ b/NexStock1.0/ViewModels/LoginViewModel.swift
@@ -29,6 +29,8 @@ class LoginViewModel: ObservableObject {
                     print("✅ Login exitoso. Token: \(response.accessToken)")
                     UserDefaults.standard.set(response.accessToken, forKey: "authToken")
                     self?.isLoggedIn = true
+                    // Obtener configuraci\u00f3n del sistema al iniciar sesi\u00f3n
+                    SystemConfigViewModel().fetchConfig()
                     completion(true)
                 case .failure(let error):
                     self?.errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- store logo URL in `AuthService`
- fetch system configuration with auth headers
- update stored logo when uploading or fetching
- load config after login
- replace header's red circle with backend logo if available

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme NexStock1.0 -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff7e2e3c8327bad2a9d053f974f2