### PR TITLE
Load color theme from backend

### DIFF
--- a/NexStock1.0/NexStock1_0App.swift
+++ b/NexStock1.0/NexStock1_0App.swift
@@ -22,6 +22,7 @@ struct NexStock1_0App: App {
             AppView()
                 .environmentObject(localizationManager)
                 .environmentObject(authService)
+                .environmentObject(ThemeManager.shared)
         }
     }
 

--- a/NexStock1.0/Services/AuthService.swift
+++ b/NexStock1.0/Services/AuthService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum AuthError: LocalizedError {
     case invalidCredentials
@@ -66,6 +67,16 @@ class AuthService: ObservableObject {
 
                 DispatchQueue.main.async {
                     self.token = decoded.accessToken
+                    self.logoURL = decoded.settings.logo_url
+                    if let p = Color(hex: decoded.settings.color_primary) {
+                        ThemeManager.shared.primaryColor = p
+                    }
+                    if let s = Color(hex: decoded.settings.color_secondary) {
+                        ThemeManager.shared.secondaryColor = s
+                    }
+                    if let t = Color(hex: decoded.settings.color_tertiary) {
+                        ThemeManager.shared.tertiaryColor = t
+                    }
                 }
 
                 completion(.success(decoded))

--- a/NexStock1.0/Utils/Color+Theme.swift
+++ b/NexStock1.0/Utils/Color+Theme.swift
@@ -9,9 +9,9 @@
 import SwiftUI
 
 extension Color {
-    static let primaryColor = Color("appPrimaryColor")
+    static var primaryColor: Color { ThemeManager.shared.primaryColor }
     static let backColor = Color("appBackColor")
-    static let secondaryColor = Color("appSecondaryColor")
-    static let tertiaryColor = Color("appTertiaryColor")
+    static var secondaryColor: Color { ThemeManager.shared.secondaryColor }
+    static var tertiaryColor: Color { ThemeManager.shared.tertiaryColor }
     static let fourthColor = Color("appFourthColor")
 }

--- a/NexStock1.0/Utils/ThemeManager.swift
+++ b/NexStock1.0/Utils/ThemeManager.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+class ThemeManager: ObservableObject {
+    static let shared = ThemeManager()
+
+    @Published var primaryColor: Color = Color("appPrimaryColor")
+    @Published var secondaryColor: Color = Color("appSecondaryColor")
+    @Published var tertiaryColor: Color = Color("appTertiaryColor")
+}

--- a/NexStock1.0/View/AlertSectionView.swift
+++ b/NexStock1.0/View/AlertSectionView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct AlertSectionView: View {
     let alerts: [AlertModel]
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         VStack(alignment: .center, spacing: 15) {

--- a/NexStock1.0/View/CardView.swift
+++ b/NexStock1.0/View/CardView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CardView: View {
     let model: CardModel
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         VStack(spacing: 12) {

--- a/NexStock1.0/View/HeaderModeView.swift
+++ b/NexStock1.0/View/HeaderModeView.swift
@@ -12,6 +12,7 @@ struct HeaderModeView: View {
     var title: String
     var showRedDot: Bool = false
     var onBack: (() -> Void)? = nil
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         HStack {

--- a/NexStock1.0/View/HeaderView.swift
+++ b/NexStock1.0/View/HeaderView.swift
@@ -14,6 +14,7 @@ struct HeaderView: View {
     @Environment(\.sizeCategory) var sizeCategory
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var authService: AuthService
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         HStack {

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InventoryCardView: View {
     let product: ProductModel
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         VStack(spacing: 8) {

--- a/NexStock1.0/View/LoginView.swift
+++ b/NexStock1.0/View/LoginView.swift
@@ -12,6 +12,7 @@ struct LoginView: View {
     @State private var isPasswordVisible = false
     @Environment(\.colorScheme) var colorScheme
     @Binding var path: NavigationPath
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         GeometryReader { geometry in

--- a/NexStock1.0/View/SectionContainer.swift
+++ b/NexStock1.0/View/SectionContainer.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct SectionContainer<Content: View>: View {
     let title: String
     let content: Content
+    @EnvironmentObject var theme: ThemeManager
 
     init(title: String, @ViewBuilder content: () -> Content) {
         self.title = title

--- a/NexStock1.0/View/SideMenuView.swift
+++ b/NexStock1.0/View/SideMenuView.swift
@@ -12,6 +12,7 @@ struct SideMenuView: View {
     @Binding var path: NavigationPath
     @State private var activeMenu: String? = nil
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
 
     private var topSafeArea: CGFloat {
         UIApplication.shared.connectedScenes

--- a/NexStock1.0/View/SystemConfigView.swift
+++ b/NexStock1.0/View/SystemConfigView.swift
@@ -15,6 +15,7 @@ struct SystemConfigView: View {
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var authService: AuthService
+    @EnvironmentObject var theme: ThemeManager
 
     @Environment(\.presentationMode) var presentationMode
 

--- a/NexStock1.0/View/UserManagementView.swift
+++ b/NexStock1.0/View/UserManagementView.swift
@@ -20,6 +20,7 @@ struct UserManagementView: View {
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.colorScheme) var colorScheme
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
 
     var body: some View {
         ZStack {

--- a/NexStock1.0/ViewModels/SystemConfigViewModel.swift
+++ b/NexStock1.0/ViewModels/SystemConfigViewModel.swift
@@ -28,9 +28,18 @@ class SystemConfigViewModel: ObservableObject {
             }
 
             DispatchQueue.main.async {
-                if let p = Color(hex: response.color_primary) { self.primaryColor = p }
-                if let s = Color(hex: response.color_secondary) { self.secondaryColor = s }
-                if let t = Color(hex: response.color_tertiary) { self.tertiaryColor = t }
+                if let p = Color(hex: response.color_primary) {
+                    self.primaryColor = p
+                    ThemeManager.shared.primaryColor = p
+                }
+                if let s = Color(hex: response.color_secondary) {
+                    self.secondaryColor = s
+                    ThemeManager.shared.secondaryColor = s
+                }
+                if let t = Color(hex: response.color_tertiary) {
+                    self.tertiaryColor = t
+                    ThemeManager.shared.tertiaryColor = t
+                }
                 self.logoURL = response.logo_url
                 self.authService.logoURL = response.logo_url
             }
@@ -54,6 +63,9 @@ class SystemConfigViewModel: ObservableObject {
         isSaving = false
 
         if colorResult && logoResult {
+            ThemeManager.shared.primaryColor = primaryColor
+            ThemeManager.shared.secondaryColor = secondaryColor
+            ThemeManager.shared.tertiaryColor = tertiaryColor
             showSuccessAlert = true
         } else {
             showErrorAlert = true


### PR DESCRIPTION
## Summary
- introduce `ThemeManager` singleton to hold dynamic colors
- make theme colors use `ThemeManager` values
- update `AuthService` and `SystemConfigViewModel` to sync backend colors
- expose theme manager to views and add environment object requirements

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68573511636483278e0352a74ad8580a