### PR TITLE
Animated login background and theme tweaks

### DIFF
--- a/NexStock1.0/View/AlertSectionView.swift
+++ b/NexStock1.0/View/AlertSectionView.swift
@@ -27,19 +27,23 @@ struct AlertSectionView: View {
 
                     Text(alert.message)
                         .font(.subheadline)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .multilineTextAlignment(.center)
                         .lineLimit(nil)
                         .minimumScaleFactor(0.8)
 
                     Text(alert.time)
                         .font(.caption2)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
-                .background(Color.tertiaryColor)
+                .background(Color.secondaryColor)
                 .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.tertiaryColor.opacity(0.2), lineWidth: 1)
+                )
                 .shadow(radius: 2)
                 .padding(.horizontal)
             }

--- a/NexStock1.0/View/AnimatedBackground.swift
+++ b/NexStock1.0/View/AnimatedBackground.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct AnimatedBackground: View {
+    @State private var animate = false
+
+    var body: some View {
+        LinearGradient(
+            gradient: Gradient(colors: [
+                Color.primaryColor,
+                Color.secondaryColor,
+                Color.tertiaryColor,
+                Color.primaryColor
+            ]),
+            startPoint: animate ? .topLeading : .bottomTrailing,
+            endPoint: animate ? .bottomTrailing : .topLeading
+        )
+        .animation(.linear(duration: 8).repeatForever(autoreverses: true), value: animate)
+        .onAppear { animate = true }
+    }
+}

--- a/NexStock1.0/View/CardView.swift
+++ b/NexStock1.0/View/CardView.swift
@@ -16,24 +16,24 @@ struct CardView: View {
             Text(model.title)
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.fourthColor)
+                .foregroundColor(.tertiaryColor)
                 .minimumScaleFactor(0.5)
                 .lineLimit(1)
 
             Text(model.subtitle)
                 .font(.headline)
-                .foregroundColor(.fourthColor.opacity(0.6))
+                .foregroundColor(.tertiaryColor.opacity(0.6))
                 .minimumScaleFactor(0.5)
                 .lineLimit(1)
         }
         
         .frame(width: 160, height: 160)
         .padding(EdgeInsets(top: 20, leading: 10, bottom: 20, trailing: 10))
-        .background(Color.tertiaryColor)
+        .background(Color.secondaryColor)
         .cornerRadius(12)
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.fourthColor.opacity(0.2), lineWidth: 1)
+                .stroke(Color.tertiaryColor.opacity(0.2), lineWidth: 1)
         )
         .shadow(radius: 3)
     }

--- a/NexStock1.0/View/HeaderModeView.swift
+++ b/NexStock1.0/View/HeaderModeView.swift
@@ -22,14 +22,14 @@ struct HeaderModeView: View {
             }) {
                 Image(systemName: "chevron.left")
                     .font(.title2)
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
             }
 
             Spacer()
 
             Text(title)
                 .font(.headline)
-                .foregroundColor(.fourthColor)
+                .foregroundColor(.tertiaryColor)
 
             Spacer()
 
@@ -44,6 +44,6 @@ struct HeaderModeView: View {
         .padding(.horizontal)
         .padding(.top, 10)
         .padding(.bottom, 4)
-        .background(Color.secondaryColor)
+        .background(Color.primaryColor)
     }
 }

--- a/NexStock1.0/View/HeaderView.swift
+++ b/NexStock1.0/View/HeaderView.swift
@@ -26,7 +26,7 @@ struct HeaderView: View {
             }) {
                 Image(systemName: "line.horizontal.3")
                     .font(iconFont)
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
             }
 
             Spacer()
@@ -37,16 +37,16 @@ struct HeaderView: View {
                     VStack(spacing: 2) {
                         Text("welcome".localized)
                             .font(.caption)
-                            .foregroundColor(.fourthColor)
+                            .foregroundColor(.tertiaryColor)
                         Text("Jose Rodriguez")
                             .font(.caption2)
-                            .foregroundColor(.fourthColor)
+                            .foregroundColor(.tertiaryColor)
                     }
                     .transition(.opacity)
                 } else {
                     Text("NexStock")
                         .font(.headline)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .transition(.opacity)
                 }
             }
@@ -83,7 +83,7 @@ struct HeaderView: View {
         .padding(.horizontal)
         .padding(.top, 10)
         .padding(.bottom, 6)
-        .background(Color.secondaryColor)
+        .background(Color.primaryColor)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                 withAnimation {

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -21,7 +21,7 @@ struct InventoryCardView: View {
 
             Text(product.name)
                 .font(.headline)
-                .foregroundColor(.fourthColor)
+                .foregroundColor(.tertiaryColor)
 
             //Text(product.quantity)
               //  .font(.caption)

--- a/NexStock1.0/View/LoginView.swift
+++ b/NexStock1.0/View/LoginView.swift
@@ -17,13 +17,9 @@ struct LoginView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                // Fondo con degradado para un estilo más limpio
-                LinearGradient(
-                    colors: [Color.primaryColor, Color.secondaryColor],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-                .ignoresSafeArea()
+                // Fondo animado con barrido de colores
+                AnimatedBackground()
+                    .ignoresSafeArea()
 
                 ScrollView {
                     let spacing = max(geometry.size.height * 0.08, 20)

--- a/NexStock1.0/View/SectionContainer.swift
+++ b/NexStock1.0/View/SectionContainer.swift
@@ -35,11 +35,11 @@ struct SectionContainer<Content: View>: View {
                 content
             }
             .padding()
-            .background(Color.tertiaryColor)
+            .background(Color.secondaryColor)
             .cornerRadius(15)
             .overlay(
                 RoundedRectangle(cornerRadius: 15)
-                    .stroke(Color.fourthColor.opacity(0.2), lineWidth: 1)
+                    .stroke(Color.tertiaryColor.opacity(0.2), lineWidth: 1)
             )
         }
     }
@@ -55,20 +55,20 @@ struct SettingRow: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: icon)
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
                     .font(.body)
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
                         .font(.body)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .multilineTextAlignment(.leading)
                         .lineLimit(nil)
 
                     if let subtitle = subtitle {
                         Text(subtitle)
                             .font(.caption)
-                            .foregroundColor(.fourthColor.opacity(0.7))
+                            .foregroundColor(.tertiaryColor.opacity(0.7))
                             .lineLimit(nil)
                     }
                 }
@@ -91,12 +91,12 @@ struct ToggleRow: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
                 Image(systemName: icon)
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
                     .font(.body)
 
                 Text(title)
                     .font(.body)
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
                     .multilineTextAlignment(.leading)
                     .lineLimit(nil)
 
@@ -121,12 +121,12 @@ struct SettingsTile: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 40, height: 40)
-                .foregroundColor(.fourthColor)
+                .foregroundColor(.tertiaryColor)
 
             Text(title)
                 .font(.body)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryColor)
+                .foregroundColor(.tertiaryColor)
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
                 .minimumScaleFactor(0.7)

--- a/NexStock1.0/View/SideMenuView.swift
+++ b/NexStock1.0/View/SideMenuView.swift
@@ -44,7 +44,7 @@ struct SideMenuView: View {
                         } label: {
                             Image(systemName: "xmark")
                                 .font(.system(size: 26, weight: .bold))
-                                .foregroundColor(.fourthColor)
+                                .foregroundColor(.tertiaryColor)
                                 .padding(.trailing)
                         }
                     }
@@ -54,7 +54,7 @@ struct SideMenuView: View {
                         path.append(AppRoute.home)
                     }
                     .font(.title3.bold())
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
 
                     // Finanzas
                     Button {
@@ -64,7 +64,7 @@ struct SideMenuView: View {
                     } label: {
                         Text("finance".localized)
                             .font(.title3.bold())
-                            .foregroundColor(.fourthColor)
+                            .foregroundColor(.tertiaryColor)
                     }
 
                     if activeMenu == "finanzas" {
@@ -76,7 +76,7 @@ struct SideMenuView: View {
                             Text("analysis".localized)
                         }
                         .font(.body)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .padding(.leading, 12)
                     }
 
@@ -88,7 +88,7 @@ struct SideMenuView: View {
                     } label: {
                         Text("inventory".localized)
                             .font(.title3.bold())
-                            .foregroundColor(.fourthColor)
+                            .foregroundColor(.tertiaryColor)
                     }
 
                     if activeMenu == "inventario" {
@@ -101,7 +101,7 @@ struct SideMenuView: View {
                             Text("Almacén")
                         }
                         .font(.body)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .padding(.leading, 12)
                     }
 
@@ -113,7 +113,7 @@ struct SideMenuView: View {
                     } label: {
                         Text("monitoring".localized)
                             .font(.title3.bold())
-                            .foregroundColor(.fourthColor)
+                            .foregroundColor(.tertiaryColor)
                     }
 
                     if activeMenu == "monitoreo" {
@@ -137,7 +137,7 @@ struct SideMenuView: View {
                             }
                         }
                         .font(.body)
-                        .foregroundColor(.fourthColor)
+                        .foregroundColor(.tertiaryColor)
                         .padding(.leading, 12)
                     }
 
@@ -153,13 +153,13 @@ struct SideMenuView: View {
                         }
                     }
                     .font(.title3.bold())
-                    .foregroundColor(.fourthColor)
+                    .foregroundColor(.tertiaryColor)
                     .padding(.bottom, 40)
                 }
                 .padding(.top, topSafeArea + 16)
                 .padding(.horizontal)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.secondaryColor)
+                .background(Color.primaryColor)
                 .ignoresSafeArea()
                 .transition(.move(edge: .leading))
                 .animation(.easeInOut, value: isOpen)


### PR DESCRIPTION
## Summary
- add animated gradient background component
- use AnimatedBackground in `LoginView`
- switch header and side menu to use the primary color
- update cards and containers to use secondary background and tertiary text/strokes
- adjust text colors to tertiary color

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6859ad5944008327b6637993114bb3aa