### PR TITLE
Add color palettes

### DIFF
--- a/NexStock1.0/Resources/de.json
+++ b/NexStock1.0/Resources/de.json
@@ -72,4 +72,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "Paletten"
 }

--- a/NexStock1.0/Resources/en.json
+++ b/NexStock1.0/Resources/en.json
@@ -77,4 +77,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "Palettes"
 }

--- a/NexStock1.0/Resources/es.json
+++ b/NexStock1.0/Resources/es.json
@@ -73,4 +73,5 @@
   "backend_error": "Error al comunicarse con el servidor",
   "logo_updated": "Logo actualizado",
   "logo_error": "Error al actualizar el logo"
+  ,"palettes": "Paletas"
 }

--- a/NexStock1.0/Resources/fr.json
+++ b/NexStock1.0/Resources/fr.json
@@ -74,4 +74,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "Palettes"
 }

--- a/NexStock1.0/Resources/it.json
+++ b/NexStock1.0/Resources/it.json
@@ -72,4 +72,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "Palette"
 }

--- a/NexStock1.0/Resources/ja.json
+++ b/NexStock1.0/Resources/ja.json
@@ -72,4 +72,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "パレット"
 }

--- a/NexStock1.0/Resources/zh.json
+++ b/NexStock1.0/Resources/zh.json
@@ -72,4 +72,5 @@
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
+  ,"palettes": "调色板"
 }

--- a/NexStock1.0/Utils/ColorPalette.swift
+++ b/NexStock1.0/Utils/ColorPalette.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ColorPalette: Identifiable {
+    let id = UUID()
+    let name: String
+    let primary: Color
+    let secondary: Color
+    let tertiary: Color
+
+    static let predefined: [ColorPalette] = [
+        ColorPalette(name: "Sunset", primary: Color(hex: "#FF5733")!, secondary: Color(hex: "#FF8D1A")!, tertiary: Color(hex: "#FFC300")!),
+        ColorPalette(name: "Ocean", primary: Color(hex: "#0077B6")!, secondary: Color(hex: "#0096C7")!, tertiary: Color(hex: "#00B4D8")!),
+        ColorPalette(name: "Forest", primary: Color(hex: "#2E7D32")!, secondary: Color(hex: "#4CAF50")!, tertiary: Color(hex: "#81C784")!),
+        ColorPalette(name: "Pastel", primary: Color(hex: "#FADCD9")!, secondary: Color(hex: "#D4E09B")!, tertiary: Color(hex: "#A9DEF9")!),
+        ColorPalette(name: "Candy", primary: Color(hex: "#FF70A6")!, secondary: Color(hex: "#FF9770")!, tertiary: Color(hex: "#FFD670")!),
+        ColorPalette(name: "Fire", primary: Color(hex: "#D62828")!, secondary: Color(hex: "#F77F00")!, tertiary: Color(hex: "#FCBF49")!),
+        ColorPalette(name: "Ice", primary: Color(hex: "#48CAE4")!, secondary: Color(hex: "#ADE8F4")!, tertiary: Color(hex: "#CAF0F8")!),
+        ColorPalette(name: "Earth", primary: Color(hex: "#8D6E63")!, secondary: Color(hex: "#A1887F")!, tertiary: Color(hex: "#D7CCC8")!),
+        ColorPalette(name: "Lavender", primary: Color(hex: "#B388EB")!, secondary: Color(hex: "#D3ABF5")!, tertiary: Color(hex: "#F7C9FF")!),
+        ColorPalette(name: "Peach", primary: Color(hex: "#FFAD69")!, secondary: Color(hex: "#FFD0A1")!, tertiary: Color(hex: "#FFE1C6")!),
+        ColorPalette(name: "Mint", primary: Color(hex: "#06D6A0")!, secondary: Color(hex: "#96F7D2")!, tertiary: Color(hex: "#C4FCEF")!),
+        ColorPalette(name: "Royal", primary: Color(hex: "#4361EE")!, secondary: Color(hex: "#4895EF")!, tertiary: Color(hex: "#4CC9F0")!),
+        ColorPalette(name: "Vintage", primary: Color(hex: "#706677")!, secondary: Color(hex: "#A59093")!, tertiary: Color(hex: "#DEC9C3")!),
+        ColorPalette(name: "Tropical", primary: Color(hex: "#FF7F51")!, secondary: Color(hex: "#FFB347")!, tertiary: Color(hex: "#FFD56F")!),
+        ColorPalette(name: "Mono", primary: Color(hex: "#555555")!, secondary: Color(hex: "#888888")!, tertiary: Color(hex: "#CCCCCC")!)
+    ]
+}

--- a/NexStock1.0/View/SystemConfigView.swift
+++ b/NexStock1.0/View/SystemConfigView.swift
@@ -97,6 +97,21 @@ struct SystemConfigView: View {
                             .foregroundColor(.primary)
                             .frame(maxWidth: .infinity, alignment: .center)
 
+                        // 🎨 Paletas predefinidas
+                        Text("palettes".localized)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 12) {
+                                ForEach(viewModel.palettes) { palette in
+                                    palettePreview(palette)
+                                }
+                            }
+                            .padding(.horizontal)
+                        }
+
                         // 🎨 Paleta 2x2
                         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 20) {
                             SectionContainer(title: "primary".localized) {
@@ -177,5 +192,28 @@ struct SystemConfigView: View {
                 .clipShape(Circle())
         }
         .frame(maxWidth: .infinity)
+    }
+
+    // 🎨 Vista de paleta de colores
+    @ViewBuilder
+    private func palettePreview(_ palette: ColorPalette) -> some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 4) {
+                Circle().fill(palette.primary).frame(width: 20, height: 20)
+                Circle().fill(palette.secondary).frame(width: 20, height: 20)
+                Circle().fill(palette.tertiary).frame(width: 20, height: 20)
+            }
+            Text(palette.name)
+                .font(.caption2)
+                .foregroundColor(.primary)
+        }
+        .padding(6)
+        .background(Color.secondaryColor.opacity(0.5))
+        .cornerRadius(8)
+        .onTapGesture {
+            viewModel.primaryColor = palette.primary
+            viewModel.secondaryColor = palette.secondary
+            viewModel.tertiaryColor = palette.tertiary
+        }
     }
 }

--- a/NexStock1.0/ViewModels/SystemConfigViewModel.swift
+++ b/NexStock1.0/ViewModels/SystemConfigViewModel.swift
@@ -3,6 +3,8 @@ import SwiftUI
 class SystemConfigViewModel: ObservableObject {
     private let authService = AuthService.shared
 
+    let palettes = ColorPalette.predefined
+
     @Published var primaryColor: Color = .primaryColor
     @Published var secondaryColor: Color = .secondaryColor
     @Published var tertiaryColor: Color = .tertiaryColor


### PR DESCRIPTION
## Summary
- add `ColorPalette` model with 15 predefined themes
- allow selecting palettes in SystemConfigView
- expose palettes via SystemConfigViewModel
- localize new `palettes` string

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859bc01376c8327878ed73e24a124ee