### PR TITLE
Agrega spinner y actualiza idioma/tema al instante

### DIFF
--- a/NexStock1.0/View/LoginView.swift
+++ b/NexStock1.0/View/LoginView.swift
@@ -99,6 +99,17 @@ struct LoginView: View {
                     .padding()
                 }
             }
+            .overlay(
+                Group {
+                    if viewModel.isLoading {
+                        Color.black.opacity(0.4).ignoresSafeArea()
+                        ProgressView("Verificando...")
+                            .padding(20)
+                            .background(.regularMaterial)
+                            .cornerRadius(12)
+                    }
+                }
+            )
         }
     }
 

--- a/NexStock1.0/View/SectionContainer.swift
+++ b/NexStock1.0/View/SectionContainer.swift
@@ -50,6 +50,8 @@ struct SettingRow: View {
     var icon: String
     var title: String
     var subtitle: String? = nil
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -86,6 +88,8 @@ struct ToggleRow: View {
     var icon: String
     var title: String
     @Binding var isOn: Bool
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -114,6 +118,8 @@ struct ToggleRow: View {
 struct SettingsTile: View {
     var iconName: String
     var title: String
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(spacing: 16) {

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -138,6 +138,7 @@ struct SettingsView: View {
             }
         }
         .onChange(of: selectedLanguage) { newLanguage in
+            localization.selectedLanguage = newLanguage
             simulatePatchPreferences(language: newLanguage, theme: selectedAppearance)
         }
         .onChange(of: selectedAppearance) { newTheme in

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @AppStorage("selectedAppearance") private var selectedAppearance: String = "system"
     @AppStorage("selectedLanguage") private var selectedLanguage: String = "es"
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
     @State private var notificationsEnabled = true
     @State private var userRole: UserRole = .admin
     @Environment(\.presentationMode) var presentationMode
@@ -119,12 +120,12 @@ struct SettingsView: View {
                                 .padding(.top, 4)
 
                             VStack(spacing: 8) {
-                                SettingsTile(iconName: "person.3.fill", title: "Usuarios")
+                                SettingsTile(iconName: "person.3.fill", title: "users".localized)
                                     .onTapGesture {
                                         path.append(AppRoute.userManagement)
                                     }
 
-                                SettingsTile(iconName: "desktopcomputer", title: "Sistema")
+                                SettingsTile(iconName: "desktopcomputer", title: "system".localized)
                                     .onTapGesture {
                                         path.append(AppRoute.systemConfig)
                                     }

--- a/NexStock1.0/View/SystemConfigView.swift
+++ b/NexStock1.0/View/SystemConfigView.swift
@@ -170,9 +170,18 @@ struct SystemConfigView: View {
             previewTheme.tertiaryColor = viewModel.tertiaryColor
             viewModel.fetchConfig()
         }
-        .onChange(of: viewModel.primaryColor) { previewTheme.primaryColor = $0 }
-        .onChange(of: viewModel.secondaryColor) { previewTheme.secondaryColor = $0 }
-        .onChange(of: viewModel.tertiaryColor) { previewTheme.tertiaryColor = $0 }
+        .onChange(of: viewModel.primaryColor) { newColor in
+            previewTheme.primaryColor = newColor
+            theme.primaryColor = newColor
+        }
+        .onChange(of: viewModel.secondaryColor) { newColor in
+            previewTheme.secondaryColor = newColor
+            theme.secondaryColor = newColor
+        }
+        .onChange(of: viewModel.tertiaryColor) { newColor in
+            previewTheme.tertiaryColor = newColor
+            theme.tertiaryColor = newColor
+        }
         .sheet(isPresented: $showImagePicker) {
 
             ImagePicker(sourceType: sourceType) { image in


### PR DESCRIPTION
## Summary
- refresh theme when colors change
- refresh app language immediately on change
- show loading spinner when verifying login

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6859cd4175308327a7ceaf334053553c