### PR TITLE
Ensure settings react to theme and language updates

### DIFF
--- a/NexStock1.0/View/SectionContainer.swift
+++ b/NexStock1.0/View/SectionContainer.swift
@@ -50,6 +50,8 @@ struct SettingRow: View {
     var icon: String
     var title: String
     var subtitle: String? = nil
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -86,6 +88,8 @@ struct ToggleRow: View {
     var icon: String
     var title: String
     @Binding var isOn: Bool
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -114,6 +118,8 @@ struct ToggleRow: View {
 struct SettingsTile: View {
     var iconName: String
     var title: String
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(spacing: 16) {

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @AppStorage("selectedAppearance") private var selectedAppearance: String = "system"
     @AppStorage("selectedLanguage") private var selectedLanguage: String = "es"
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
     @State private var notificationsEnabled = true
     @State private var userRole: UserRole = .admin
     @Environment(\.presentationMode) var presentationMode
@@ -119,12 +120,12 @@ struct SettingsView: View {
                                 .padding(.top, 4)
 
                             VStack(spacing: 8) {
-                                SettingsTile(iconName: "person.3.fill", title: "Usuarios")
+                                SettingsTile(iconName: "person.3.fill", title: "users".localized)
                                     .onTapGesture {
                                         path.append(AppRoute.userManagement)
                                     }
 
-                                SettingsTile(iconName: "desktopcomputer", title: "Sistema")
+                                SettingsTile(iconName: "desktopcomputer", title: "system".localized)
                                     .onTapGesture {
                                         path.append(AppRoute.systemConfig)
                                     }


### PR DESCRIPTION
## Summary
- listen for theme updates in SettingsView
- localize advanced cards titles
- have SectionContainer subviews observe theme and localization changes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6859e63b9c188327999c0fc9e2781ee0