### PR TITLE
Update alert screen with color severity

### DIFF
--- a/NexStock1.0/Models/AlertModel.swift
+++ b/NexStock1.0/Models/AlertModel.swift
@@ -7,6 +7,21 @@
 
 
 import Foundation
+import SwiftUI
+
+/// Level of importance for an alert. Each level defines its visual color.
+enum AlertSeverity {
+    case low, medium, high
+
+    /// Base color associated to each severity level
+    var color: Color {
+        switch self {
+        case .low: return .green
+        case .medium: return .yellow
+        case .high: return .red
+        }
+    }
+}
 
 struct AlertModel: Identifiable {
     let id = UUID()
@@ -14,4 +29,5 @@ struct AlertModel: Identifiable {
     let message: String
     let time: String
     let icon: String
+    let severity: AlertSeverity
 }

--- a/NexStock1.0/View/AlertSectionView.swift
+++ b/NexStock1.0/View/AlertSectionView.swift
@@ -22,7 +22,7 @@ struct AlertSectionView: View {
             ForEach(alerts) { alert in
                 VStack(spacing: 8) {
                     Image(systemName: alert.icon)
-                        .foregroundColor(.yellow)
+                        .foregroundColor(alert.severity.color)
                         .font(.title2)
 
                     Text(alert.message)
@@ -38,7 +38,13 @@ struct AlertSectionView: View {
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
-                .background(Color.secondaryColor)
+                .background(
+                    LinearGradient(
+                        colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
                 .cornerRadius(10)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -14,9 +14,9 @@ struct AlertView: View {
     @EnvironmentObject var theme: ThemeManager
 
     let alerts: [AlertModel] = [
-        .init(sensor: "Sensor de movimiento", message: "Se ha detectado una vibración fuerte en la zona A.", time: "13:42", icon: "exclamationmark.triangle.fill"),
-        .init(sensor: "Sensor de gases", message: "Alta concentración de gas detectada en la cocina.", time: "12:10", icon: "exclamationmark.triangle.fill"),
-        .init(sensor: "Sensor de humedad", message: "Aumento repentino de humedad detectado.", time: "2 de junio", icon: "exclamationmark.triangle.fill")
+        .init(sensor: "Sensor de movimiento", message: "Se ha detectado una vibración fuerte en la zona A.", time: "13:42", icon: "exclamationmark.triangle.fill", severity: .high),
+        .init(sensor: "Sensor de gases", message: "Alta concentración de gas detectada en la cocina.", time: "12:10", icon: "exclamationmark.triangle.fill", severity: .medium),
+        .init(sensor: "Sensor de humedad", message: "Aumento repentino de humedad detectado.", time: "2 de junio", icon: "exclamationmark.triangle.fill", severity: .low)
     ]
 
     var body: some View {
@@ -35,7 +35,7 @@ struct AlertView: View {
                         ForEach(alerts) { alert in
                             HStack(alignment: .top, spacing: 12) {
                                 Image(systemName: alert.icon)
-                                    .foregroundColor(.yellow)
+                                    .foregroundColor(alert.severity.color)
                                     .font(.system(size: 18))
                                     .padding(.top, 2)
 
@@ -53,7 +53,13 @@ struct AlertView: View {
                                         .font(.body)
                                 }
                                 .padding(12)
-                                .background(Color.white.opacity(0.1))
+                                .background(
+                                    LinearGradient(
+                                        colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing
+                                    )
+                                )
                                 .cornerRadius(10)
                             }
                             .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -31,9 +31,9 @@ struct HomeView: View {
                         ])
 
                         AlertSectionView(alerts: [
-                            AlertModel(sensor: "Sensor de movimiento", message: "Movimiento detectado en zona 3", time: "14:22 h", icon: "exclamationmark.triangle.fill"),
-                            AlertModel(sensor: "Sensor de humedad", message: "Humedad superior al 80%", time: "13:45 h", icon: "exclamationmark.triangle.fill"),
-                            AlertModel(sensor: "Sensor de temperatura", message: "Temperatura superior a 25 grados", time: "12:13 h", icon: "exclamationmark.triangle.fill")
+                            AlertModel(sensor: "Sensor de movimiento", message: "Movimiento detectado en zona 3", time: "14:22 h", icon: "exclamationmark.triangle.fill", severity: .high),
+                            AlertModel(sensor: "Sensor de humedad", message: "Humedad superior al 80%", time: "13:45 h", icon: "exclamationmark.triangle.fill", severity: .medium),
+                            AlertModel(sensor: "Sensor de temperatura", message: "Temperatura superior a 25 grados", time: "12:13 h", icon: "exclamationmark.triangle.fill", severity: .low)
                         ])
                     }
                     .padding()


### PR DESCRIPTION
## Summary
- add `AlertSeverity` enum with color mapping
- colorize alerts in both alert screens
- update example alerts with severity levels

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6859e8f6d4b083279d8419bfc012b94d