### PR TITLE
Add inventory detail popup

### DIFF
--- a/NexStock1.0/Models/InventorySummary.swift
+++ b/NexStock1.0/Models/InventorySummary.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct InventoryProduct: Identifiable, Codable {
+    let id = UUID()
+    let name: String
+    let stock_actual: Int?
+    let expiration_date: String?
+    let image_url: String?
+    let sensor_type: String?
+    let stock_minimum: Int?
+    let stock_maximum: Int?
+}
+
+struct InventorySummary: Codable {
+    let message: String
+    let expiring: [InventoryProduct]
+    let out_of_stock: [InventoryProduct]
+    let low_stock: [InventoryProduct]
+    let near_minimum: [InventoryProduct]
+    let overstock: [InventoryProduct]
+    let all: [InventoryProduct]
+}

--- a/NexStock1.0/Services/InventoryService.swift
+++ b/NexStock1.0/Services/InventoryService.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+class InventoryService {
+    static let shared = InventoryService()
+    private let baseURL = "https://inventory.nexusutd.online"
+
+    func fetchSummary(completion: @escaping (Result<InventorySummary, Error>) -> Void) {
+        guard let url = URL(string: "\(baseURL)/inventory/home") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(InventorySummary.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InventoryCardView: View {
     let product: ProductModel
+    var onTap: (() -> Void)? = nil
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -32,5 +33,8 @@ struct InventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture {
+            onTap?()
+        }
     }
 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -19,6 +19,8 @@ struct InventoryScreenView: View {
     @State private var searchText: String = ""
     @State private var showAddProductSheet = false
     @State private var products: [ProductModel] = sampleProducts
+    @State private var selectedProduct: ProductModel? = nil
+    @State private var showDetailSheet = false
 
     let categories: [Category] = [
         Category(id: 1, name: "Frutas"),
@@ -41,6 +43,13 @@ struct InventoryScreenView: View {
                 showAddProductSheet = false
             }
             .environmentObject(authService)
+        }
+        .sheet(isPresented: $showDetailSheet) {
+            if let selectedProduct {
+                ProductDetailSheet(product: selectedProduct)
+                    .environmentObject(theme)
+                    .environmentObject(localization)
+            }
         }
         .navigationBarBackButtonHidden(true)
         .onChange(of: showAddProductSheet) { isPresented in
@@ -92,7 +101,10 @@ struct InventoryScreenView: View {
                                 .foregroundColor(.primary)
 
                             ForEach(filtered, id: \.id) { product in
-                                InventoryCardView(product: product)
+                                InventoryCardView(product: product) {
+                                    selectedProduct = product
+                                    showDetailSheet = true
+                                }
                             }
                         }
                         .padding(.horizontal)

--- a/NexStock1.0/View/ProductDetailSheet.swift
+++ b/NexStock1.0/View/ProductDetailSheet.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct ProductDetailSheet: View {
+    let product: ProductModel
+    @State private var detail: InventoryProduct?
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                if let detail = detail {
+                    if let urlString = detail.image_url, let url = URL(string: urlString) {
+                        AsyncImage(url: url) { image in
+                            image.resizable().scaledToFit()
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .frame(height: 120)
+                    }
+
+                    Text(detail.name)
+                        .font(.title2)
+                        .bold()
+
+                    if let stock = detail.stock_actual {
+                        Text("Stock actual: \(stock)")
+                    }
+                    if let expiration = detail.expiration_date {
+                        Text("Expira: \(expiration)")
+                    }
+                    if let min = detail.stock_minimum {
+                        Text("Mínimo: \(min)")
+                    }
+                    if let max = detail.stock_maximum {
+                        Text("Máximo: \(max)")
+                    }
+                    if let sensor = detail.sensor_type {
+                        Text("Sensor: \(sensor)")
+                    }
+                } else {
+                    ProgressView()
+                }
+            }
+            .padding()
+            .navigationTitle("Detalle")
+            .onAppear(perform: loadDetail)
+        }
+    }
+
+    func loadDetail() {
+        InventoryService.shared.fetchSummary { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let summary):
+                    let items = summary.expiring + summary.out_of_stock + summary.low_stock + summary.near_minimum + summary.overstock + summary.all
+                    self.detail = items.first { $0.name == product.name }
+                case .failure(let error):
+                    print("Error fetching product detail:", error)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add models to decode inventory summary info
- implement InventoryService to call `/inventory/home`
- show product details in a new ProductDetailSheet
- open detail sheet from InventoryScreenView when a card is tapped
- make InventoryCardView tappable

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6859f3945c488327b204d0155b322a69