### PR TITLE
Integrate backend inventory summary

### DIFF
--- a/NexStock1.0/Services/InventoryService.swift
+++ b/NexStock1.0/Services/InventoryService.swift
@@ -4,6 +4,23 @@ class InventoryService {
     static let shared = InventoryService()
     private let baseURL = "https://inventory.nexusutd.online"
 
+    func fetchHomeSummary(limit: Int = 5, completion: @escaping (Result<InventoryHomeResponse, Error>) -> Void) {
+        guard let url = URL(string: "\(baseURL)/inventory/home?limit=\(limit)") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+
     func fetchDetails(for name: String, completion: @escaping (Result<InventoryProduct, Error>) -> Void) {
         guard let url = URL(string: "\(baseURL)/inventory/home") else { return }
 

--- a/NexStock1.0/View/AddProductSheet.swift
+++ b/NexStock1.0/View/AddProductSheet.swift
@@ -37,10 +37,12 @@ struct AddProductSheet: View {
     @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
     @State private var showImageSourceOptions = false
 
+    // Categories provided by the backend
     let categories: [Category] = [
         .init(id: 1, name: "Alimentos"),
         .init(id: 2, name: "Bebidas"),
-        .init(id: 3, name: "Limpieza")
+        .init(id: 3, name: "Insumos"),
+        .init(id: 4, name: "Productos de limpieza")
     ]
 
     let unitTypes: [UnitType] = [

--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct HomeInventoryCardView: View {
+    let product: InventoryProduct
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let urlString = product.image_url, let url = URL(string: urlString) {
+                AsyncImage(url: url) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 80, height: 80)
+                .cornerRadius(10)
+            }
+
+            Text(product.name)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+        }
+        .padding()
+        .background(Color.secondaryColor)
+        .cornerRadius(12)
+        .shadow(radius: 2)
+    }
+}

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HomeView: View {
     @Binding var path: NavigationPath
     @State private var showMenu = false
+    @StateObject private var inventoryVM = InventoryHomeViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
 
@@ -35,6 +36,24 @@ struct HomeView: View {
                             AlertModel(sensor: "Sensor de humedad", message: "Humedad superior al 80%", time: "13:45 h", icon: "exclamationmark.triangle.fill", severity: .medium),
                             AlertModel(sensor: "Sensor de temperatura", message: "Temperatura superior a 25 grados", time: "12:13 h", icon: "exclamationmark.triangle.fill", severity: .low)
                         ])
+
+                        if let summary = inventoryVM.summary {
+                            if let expiring = summary.expiring {
+                                InventoryHomeSectionView(title: "Por vencer", products: expiring, loadMore: inventoryVM.loadMore)
+                            }
+                            if let out = summary.out_of_stock {
+                                InventoryHomeSectionView(title: "Agotados", products: out, loadMore: inventoryVM.loadMore)
+                            }
+                            if let low = summary.low_stock {
+                                InventoryHomeSectionView(title: "Bajo stock", products: low, loadMore: inventoryVM.loadMore)
+                            }
+                            if let near = summary.near_minimum {
+                                InventoryHomeSectionView(title: "Cerca del mínimo", products: near, loadMore: inventoryVM.loadMore)
+                            }
+                            if let over = summary.overstock {
+                                InventoryHomeSectionView(title: "Sobre inventario", products: over, loadMore: inventoryVM.loadMore)
+                            }
+                        }
                     }
                     .padding()
                 }
@@ -48,6 +67,7 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
+        .onAppear { inventoryVM.fetchInitial() }
     }
 }
 

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct InventoryHomeSectionView: View {
+    let title: String
+    let products: [InventoryProduct]
+    var loadMore: (() -> Void)? = nil
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title)
+                    .font(.title3.bold())
+                    .foregroundColor(.primary)
+                Spacer()
+                if let loadMore = loadMore {
+                    Button("Ver más", action: loadMore)
+                        .font(.caption)
+                }
+            }
+            .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 20) {
+                    ForEach(products) { product in
+                        HomeInventoryCardView(product: product)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+}

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -18,16 +18,15 @@ struct InventoryScreenView: View {
     @State private var visibleLetterByCategory: [String: String] = [:]
     @State private var searchText: String = ""
     @State private var showAddProductSheet = false
-    @State private var products: [ProductModel] = sampleProducts
+    @State private var products: [ProductModel] = []
     @State private var selectedProduct: ProductModel? = nil
 
+    // Categories provided by the backend
     let categories: [Category] = [
-        Category(id: 1, name: "Frutas"),
-        Category(id: 2, name: "Verduras"),
-        Category(id: 3, name: "Lácteos"),
-        Category(id: 4, name: "Bebidas"),
-        Category(id: 5, name: "Insumos"),
-        Category(id: 6, name: "Productos de limpieza")
+        Category(id: 1, name: "Alimentos"),
+        Category(id: 2, name: "Bebidas"),
+        Category(id: 3, name: "Insumos"),
+        Category(id: 4, name: "Productos de limpieza")
     ]
 
     var body: some View {
@@ -54,6 +53,7 @@ struct InventoryScreenView: View {
                 }
             }
         }
+        .onAppear(perform: fetchProducts)
     }
     
 
@@ -122,6 +122,16 @@ struct InventoryScreenView: View {
         }
         .padding(.trailing, 24)
         .padding(.bottom, 24)
+    }
+
+    private func fetchProducts() {
+        ProductService.shared.fetchProducts { result in
+            DispatchQueue.main.async {
+                if case .success(let data) = result {
+                    self.products = data
+                }
+            }
+        }
     }
 }
     

--- a/NexStock1.0/ViewModels/InventoryHomeViewModel.swift
+++ b/NexStock1.0/ViewModels/InventoryHomeViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class InventoryHomeViewModel: ObservableObject {
+    @Published var summary: InventoryHomeResponse?
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    private var limit = 5
+
+    func fetchInitial() {
+        fetchSummary(limit: limit)
+    }
+
+    func loadMore() {
+        limit += 5
+        fetchSummary(limit: limit)
+    }
+
+    private func fetchSummary(limit: Int) {
+        isLoading = true
+        InventoryService.shared.fetchHomeSummary(limit: limit) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                switch result {
+                case .success(let data):
+                    self?.summary = data
+                case .failure(let error):
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update product categories
- fetch product list from backend in inventory screen
- add inventory home summary service
- display inventory summary on dashboard and allow loading more products

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6859f86b6634832787234d9a1b0c9752