### PR TITLE
Add product detail modal with movement history

### DIFF
--- a/NexStock1.0/Models/DetailedProductModel.swift
+++ b/NexStock1.0/Models/DetailedProductModel.swift
@@ -23,6 +23,8 @@ struct DetailedProductModel: Identifiable, Codable {
     let stock_min: Int
     let stock_max: Int
     let input_method: InputMethod
+    let stock_actual: Int?
+    let updated_at: String?
 
     init(id: Int = 0,
          name: String,
@@ -33,7 +35,9 @@ struct DetailedProductModel: Identifiable, Codable {
          image_url: String,
          stock_min: Int,
          stock_max: Int,
-         input_method: InputMethod) {
+         input_method: InputMethod,
+         stock_actual: Int? = nil,
+         updated_at: String? = nil) {
         self.id = id
         self.name = name
         self.brand = brand
@@ -44,6 +48,8 @@ struct DetailedProductModel: Identifiable, Codable {
         self.stock_min = stock_min
         self.stock_max = stock_max
         self.input_method = input_method
+        self.stock_actual = stock_actual
+        self.updated_at = updated_at
     }
 
     var localized: String {

--- a/NexStock1.0/Models/ProductMovement.swift
+++ b/NexStock1.0/Models/ProductMovement.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ProductMovement: Identifiable, Codable {
+    let id: Int
+    let timestamp: String
+    let type: String
+    let quantity: Int
+    let user: String?
+}
+
+struct ProductMovementResponse: Codable {
+    let movements: [ProductMovement]
+}

--- a/NexStock1.0/Resources/en.json
+++ b/NexStock1.0/Resources/en.json
@@ -82,7 +82,16 @@
   "config_saved": "Configuration saved",
   "backend_error": "Error communicating with server",
   "logo_updated": "Logo updated",
-  "logo_error": "Error updating logo"
-  ,"palettes": "Palettes"
-  ,"preview": "Preview"
+  "logo_error": "Error updating logo",
+  "palettes": "Palettes",
+  "preview": "Preview",
+  "information": "Information",
+  "movements": "Movements",
+  "current_stock": "Current stock",
+  "minimum_stock": "Minimum stock",
+  "maximum_stock": "Maximum stock",
+  "brand": "Brand",
+  "last_updated": "Last updated",
+  "description": "Description",
+  "no_movements": "No movements recorded"
 }

--- a/NexStock1.0/Resources/es.json
+++ b/NexStock1.0/Resources/es.json
@@ -78,7 +78,16 @@
   "config_saved": "Configuración guardada",
   "backend_error": "Error al comunicarse con el servidor",
   "logo_updated": "Logo actualizado",
-  "logo_error": "Error al actualizar el logo"
-  ,"palettes": "Paletas"
-  ,"preview": "Vista previa"
+  "logo_error": "Error al actualizar el logo",
+  "palettes": "Paletas",
+  "preview": "Vista previa",
+  "information": "Información",
+  "movements": "Movimientos",
+  "current_stock": "Existencias actuales",
+  "minimum_stock": "Stock mínimo",
+  "maximum_stock": "Stock máximo",
+  "brand": "Marca",
+  "last_updated": "Última actualización",
+  "description": "Descripción",
+  "no_movements": "No hay movimientos registrados"
 }

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -62,6 +62,41 @@ class ProductService {
         }.resume()
     }
 
+    func fetchProductDetail(id: String, completion: @escaping (Result<DetailedProductModel, Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/" + id) else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(DetailedProductModel.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+
+    func fetchMovements(for id: String, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/" + id + "/movements") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                if let decoded = try? JSONDecoder().decode(ProductMovementResponse.self, from: data) {
+                    completion(.success(decoded.movements))
+                } else if let decodedArray = try? JSONDecoder().decode([ProductMovement].self, from: data) {
+                    completion(.success(decodedArray))
+                } else {
+                    completion(.failure(NSError(domain: "Parsing", code: -1, userInfo: nil)))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+
     func addProduct(_ product: DetailedProductModel, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let url = URL(string: baseURL) else { return }
 

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
+    @Binding var selectedProduct: ProductModel?
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         ScrollView {
@@ -16,6 +18,9 @@ struct InventoryGroupView: View {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
                                         ProductCard(product: product)
+                                            .onTapGesture {
+                                                selectedProduct = product
+                                            }
                                             .onAppear {
                                                 viewModel.loadMoreIfNeeded(currentItem: product, category: category)
                                             }
@@ -50,9 +55,9 @@ struct ProductCard: View {
             }
             Text(product.name)
                 .font(.headline)
-            Text("Stock: \(product.stock_actual)")
+            Text("\("current_stock".localized): \(product.stock_actual)")
                 .font(.caption)
-            Text("Sensor: \(product.sensor_type)")
+            Text("\("sensor".localized): \(product.sensor_type)")
                 .font(.caption)
         }
         .padding()
@@ -63,7 +68,7 @@ struct ProductCard: View {
 
 struct InventoryGroupView_Previews: PreviewProvider {
     static var previews: some View {
-        InventoryGroupView()
+        InventoryGroupView(selectedProduct: .constant(nil))
             .environmentObject(ThemeManager())
             .environmentObject(LocalizationManager())
     }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -18,7 +18,7 @@ struct InventoryScreenView: View {
     @State private var visibleLetterByCategory: [String: String] = [:]
     @State private var searchText: String = ""
     @State private var showAddProductSheet = false
-    @State private var selectedProduct: DetailedProductModel? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -64,7 +64,7 @@ struct InventoryScreenView: View {
     }
 
     private var productList: some View {
-        InventoryGroupView()
+        InventoryGroupView(selectedProduct: $selectedProduct)
             .navigationBarBackButtonHidden(true)
     }
 

--- a/NexStock1.0/View/ProductDetailSheet.swift
+++ b/NexStock1.0/View/ProductDetailSheet.swift
@@ -1,20 +1,38 @@
 import SwiftUI
 
 struct ProductDetailSheet: View {
-    let product: DetailedProductModel
-    @State private var details: InventoryProduct?
+    let product: ProductModel
+    @State private var details: DetailedProductModel?
+    @State private var inventoryInfo: InventoryProduct?
+    @State private var movements: [ProductMovement] = []
     @State private var isLoading = true
+    @State private var isLoadingMovements = true
     @State private var errorMessage: String?
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         NavigationStack {
-            Group {
-                if isLoading {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle())
-                } else if let details = details {
+            if isLoading {
+                ProgressView()
+            } else {
+                TabView {
+                    infoView
+                        .tabItem { Text("information".localized) }
+                    movementsView
+                        .tabItem { Text("movements".localized) }
+                }
+            }
+        }
+        .navigationTitle(product.name)
+        .onAppear(perform: fetchData)
+    }
+
+    private var infoView: some View {
+        Group {
+            if let details = details {
+                ScrollView {
                     VStack(spacing: 12) {
-                        if let imageURL = details.image_url, let url = URL(string: imageURL) {
+                        if let url = URL(string: details.image_url) {
                             AsyncImage(url: url) { image in
                                 image.resizable()
                             } placeholder: {
@@ -22,54 +40,79 @@ struct ProductDetailSheet: View {
                             }
                             .frame(width: 150, height: 150)
                             .cornerRadius(12)
-                        } else {
-                            Image(product.image_url)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 150, height: 150)
-                                .cornerRadius(12)
                         }
-
                         Text(details.name)
                             .font(.title2.bold())
-
-                        if let stock = details.stock_actual {
-                            Text("Stock actual: \(stock)")
+                        if let stock = inventoryInfo?.stock_actual ?? details.stock_actual {
+                            Text("\("current_stock".localized): \(stock)")
                         }
-                        if let date = details.expiration_date {
-                            Text("Expira: \(date)")
+                        Text("\("minimum_stock".localized): \(details.stock_min)")
+                        Text("\("maximum_stock".localized): \(details.stock_max)")
+                        Text("\("brand".localized): \(details.brand)")
+                        if let updated = details.updated_at {
+                            Text("\("last_updated".localized): \(updated)")
                         }
-                        if let min = details.stock_minimum {
-                            Text("Mínimo: \(min)")
-                        }
-                        if let max = details.stock_maximum {
-                            Text("Máximo: \(max)")
-                        }
-                        if let sensor = details.sensor_type {
-                            Text("Sensor: \(sensor)")
-                        }
+                        Text("\("description".localized): \(details.description)")
                     }
                     .padding()
-                } else if let message = errorMessage {
-                    Text(message)
-                        .foregroundColor(.red)
                 }
+            } else if let message = errorMessage {
+                Text(message).foregroundColor(.red)
             }
-            .navigationTitle("Detalle")
-            .onAppear(perform: fetchDetails)
         }
     }
 
-    private func fetchDetails() {
-        InventoryService.shared.fetchDetails(for: product.name) { result in
+    private var movementsView: some View {
+        Group {
+            if isLoadingMovements {
+                ProgressView()
+            } else if movements.isEmpty {
+                Text("no_movements".localized)
+            } else {
+                List(movements) { move in
+                    VStack(alignment: .leading) {
+                        Text(move.timestamp)
+                        Text(move.type)
+                        Text("\(move.quantity)")
+                        if let user = move.user {
+                            Text(user)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func fetchData() {
+        ProductService.shared.fetchProductDetail(id: product.id) { result in
             DispatchQueue.main.async {
                 switch result {
-                case .success(let data):
-                    self.details = data
+                case .success(let detail):
+                    self.details = detail
                     self.isLoading = false
                 case .failure(let error):
                     self.errorMessage = error.localizedDescription
                     self.isLoading = false
+                }
+            }
+        }
+
+        InventoryService.shared.fetchDetails(for: product.name) { result in
+            DispatchQueue.main.async {
+                if case .success(let info) = result {
+                    self.inventoryInfo = info
+                }
+            }
+        }
+
+        ProductService.shared.fetchMovements(for: product.id) { result in
+            DispatchQueue.main.async {
+                self.isLoadingMovements = false
+                switch result {
+                case .success(let moves):
+                    self.movements = moves
+                case .failure:
+                    self.movements = []
                 }
             }
         }


### PR DESCRIPTION
## Summary
- include product movement model
- extend `DetailedProductModel` with current stock and last update
- support fetching detailed products and movements from API
- group inventory cards allow item tap and localization of labels
- show new detail modal with info & movements tabs
- add localized strings for detail fields in English and Spanish

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_685b066493a083279af0461a3ab14c8e