### PR TITLE
Implement localized product detail view

### DIFF
--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ProductDetailResponse: Codable {
+    let message: String?
+    let product: ProductDetailInfo
+    let movements: [ProductMovement]
+}
+
+struct ProductDetailInfo: Identifiable, Codable {
+    let id: Int
+    let name: String
+    let brand: String
+    let description: String
+    let image_url: String
+    let stock_actual: Int
+    let stock_min: Int
+    let stock_max: Int
+    let updated_at: String
+}
+
+struct ProductMovement: Identifiable, Codable {
+    let id: Int
+    let type: String
+    let quantity: Int
+    let user: String
+    let created_at: String
+}

--- a/NexStock1.0/Resources/de.json
+++ b/NexStock1.0/Resources/de.json
@@ -80,4 +80,17 @@
   "logo_error": "Error updating logo"
   ,"palettes": "Paletten"
   ,"preview": "Vorschau"
+  ,"information": "Informationen",
+  "movements": "Bewegungen",
+  "current_stock": "Aktueller Bestand",
+  "minimum_stock": "Mindestbestand",
+  "maximum_stock": "Maximalbestand",
+  "brand": "Marke",
+  "last_updated": "Zuletzt aktualisiert",
+  "description": "Beschreibung",
+  "no_movements": "Keine Bewegungen registriert",
+  "stock": "Bestand",
+  "image": "Bild",
+  "category": "Kategorie",
+  "unit": "Einheit"
 }

--- a/NexStock1.0/Resources/en.json
+++ b/NexStock1.0/Resources/en.json
@@ -84,5 +84,18 @@
   "logo_updated": "Logo updated",
   "logo_error": "Error updating logo"
   ,"palettes": "Palettes"
-  ,"preview": "Preview"
+  ,"preview": "Preview",
+  "information": "Information",
+  "movements": "Movements",
+  "current_stock": "Current stock",
+  "minimum_stock": "Minimum stock",
+  "maximum_stock": "Maximum stock",
+  "brand": "Brand",
+  "last_updated": "Last updated",
+  "description": "Description",
+  "no_movements": "No movements recorded",
+  "stock": "Stock",
+  "image": "Image",
+  "category": "Category",
+  "unit": "Unit"
 }

--- a/NexStock1.0/Resources/es.json
+++ b/NexStock1.0/Resources/es.json
@@ -81,4 +81,17 @@
   "logo_error": "Error al actualizar el logo"
   ,"palettes": "Paletas"
   ,"preview": "Vista previa"
+  ,"information": "Información",
+  "movements": "Movimientos",
+  "current_stock": "Existencia actual",
+  "minimum_stock": "Stock mínimo",
+  "maximum_stock": "Stock máximo",
+  "brand": "Marca",
+  "last_updated": "Última actualización",
+  "description": "Descripción",
+  "no_movements": "No hay movimientos registrados",
+  "stock": "Stock",
+  "image": "Imagen",
+  "category": "Categoría",
+  "unit": "Unidad"
 }

--- a/NexStock1.0/Resources/fr.json
+++ b/NexStock1.0/Resources/fr.json
@@ -82,4 +82,17 @@
   "logo_error": "Error updating logo"
   ,"palettes": "Palettes"
   ,"preview": "Aperçu"
+  ,"information": "Information",
+  "movements": "Mouvements",
+  "current_stock": "Stock actuel",
+  "minimum_stock": "Stock minimum",
+  "maximum_stock": "Stock maximum",
+  "brand": "Marque",
+  "last_updated": "Dernière mise à jour",
+  "description": "Description",
+  "no_movements": "Aucun mouvement enregistré",
+  "stock": "Stock",
+  "image": "Image",
+  "category": "Catégorie",
+  "unit": "Unité"
 }

--- a/NexStock1.0/Resources/it.json
+++ b/NexStock1.0/Resources/it.json
@@ -80,4 +80,17 @@
   "logo_error": "Error updating logo"
   ,"palettes": "Palette"
   ,"preview": "Anteprima"
+  ,"information": "Informazioni",
+  "movements": "Movimenti",
+  "current_stock": "Stock attuale",
+  "minimum_stock": "Stock minimo",
+  "maximum_stock": "Stock massimo",
+  "brand": "Marca",
+  "last_updated": "Ultimo aggiornamento",
+  "description": "Descrizione",
+  "no_movements": "Nessun movimento registrato",
+  "stock": "Stock",
+  "image": "Immagine",
+  "category": "Categoria",
+  "unit": "Unità"
 }

--- a/NexStock1.0/Resources/ja.json
+++ b/NexStock1.0/Resources/ja.json
@@ -80,4 +80,17 @@
   "logo_error": "Error updating logo"
   ,"palettes": "パレット"
   ,"preview": "プレビュー"
+  ,"information": "情報",
+  "movements": "動き",
+  "current_stock": "現在の在庫",
+  "minimum_stock": "最小在庫",
+  "maximum_stock": "最大在庫",
+  "brand": "ブランド",
+  "last_updated": "最終更新",
+  "description": "説明",
+  "no_movements": "移動はありません",
+  "stock": "在庫",
+  "image": "画像",
+  "category": "カテゴリー",
+  "unit": "単位"
 }

--- a/NexStock1.0/Resources/zh.json
+++ b/NexStock1.0/Resources/zh.json
@@ -80,4 +80,17 @@
   "logo_error": "Error updating logo"
   ,"palettes": "调色板"
   ,"preview": "预览"
+  ,"information": "信息",
+  "movements": "移动",
+  "current_stock": "当前库存",
+  "minimum_stock": "最小库存",
+  "maximum_stock": "最大库存",
+  "brand": "品牌",
+  "last_updated": "最后更新",
+  "description": "描述",
+  "no_movements": "没有记录的移动",
+  "stock": "库存",
+  "image": "图片",
+  "category": "类别",
+  "unit": "单位"
 }

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -85,4 +85,21 @@ class ProductService {
             }
         }.resume()
     }
+
+    func fetchProductDetail(id: String, completion: @escaping (Result<ProductDetailResponse, Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/" + id) else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(ProductDetailResponse.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
 }

--- a/NexStock1.0/View/AddProductSheet.swift
+++ b/NexStock1.0/View/AddProductSheet.swift
@@ -55,14 +55,14 @@ struct AddProductSheet: View {
         NavigationStack {
             Form {
                 // Sección 1
-                Section(header: Text("Información")) {
+                Section(header: Text("information".localized)) {
                     TextField("Nombre", text: $name)
                     TextField("Marca", text: $brand)
                     TextField("Descripción", text: $description)
                 }
 
                 // Sección 2
-                Section(header: Text("Stock")) {
+                Section(header: Text("stock".localized)) {
                     HStack {
                         Text("Mínimo:")
                         TextField("0", value: $stockMin, format: .number)
@@ -83,7 +83,7 @@ struct AddProductSheet: View {
                 }
 
                 // Sección 3
-                Section(header: Text("Imagen")) {
+                Section(header: Text("image".localized)) {
                     if let image = selectedImage {
                         Image(uiImage: image)
                             .resizable()
@@ -112,19 +112,19 @@ struct AddProductSheet: View {
                 }
 
                 // Sección 4
-                Section(header: Text("Categoría")) {
+                Section(header: Text("category".localized)) {
                     Picker("Categoría", selection: $selectedCategory) {
                         ForEach(categories, id: \.self) { category in
-                            Text(category.name).tag(category as Category?)
+                            Text(category.name.localized).tag(category as Category?)
                         }
                     }
                 }
 
                 // Sección 5
-                Section(header: Text("Unidad")) {
+                Section(header: Text("unit".localized)) {
                     Picker("Tipo de unidad", selection: $selectedUnitType) {
                         ForEach(unitTypes, id: \.self) { unit in
-                            Text(unit.name).tag(unit as UnitType?)
+                            Text(unit.name.localized).tag(unit as UnitType?)
                         }
                     }
                 }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
+    var onProductTap: (ProductModel) -> Void = { _ in }
 
     var body: some View {
         ScrollView {
@@ -9,16 +10,18 @@ struct InventoryGroupView: View {
                 ForEach(viewModel.categories, id: \.self) { category in
                     if let items = viewModel.productsByCategory[category], !items.isEmpty {
                         VStack(alignment: .leading, spacing: 12) {
-                            Text(category)
+                            Text(category.localized)
                                 .font(.title3.bold())
                                 .padding(.horizontal)
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        ProductCard(product: product)
-                                            .onAppear {
-                                                viewModel.loadMoreIfNeeded(currentItem: product, category: category)
-                                            }
+                                        ProductCard(product: product) {
+                                            onProductTap(product)
+                                        }
+                                        .onAppear {
+                                            viewModel.loadMoreIfNeeded(currentItem: product, category: category)
+                                        }
                                     }
                                 }
                                 .padding(.horizontal)
@@ -36,6 +39,7 @@ struct InventoryGroupView: View {
 
 struct ProductCard: View {
     let product: ProductModel
+    var onTap: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -48,16 +52,17 @@ struct ProductCard: View {
                 .frame(width: 120, height: 120)
                 .cornerRadius(8)
             }
-            Text(product.name)
+            Text(product.name.localized)
                 .font(.headline)
             Text("Stock: \(product.stock_actual)")
                 .font(.caption)
-            Text("Sensor: \(product.sensor_type)")
+            Text("Sensor: \(product.sensor_type.localized)")
                 .font(.caption)
         }
         .padding()
         .background(Color.secondaryColor)
         .cornerRadius(12)
+        .onTapGesture { onTap() }
     }
 }
 

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -18,7 +18,7 @@ struct InventoryScreenView: View {
     @State private var visibleLetterByCategory: [String: String] = [:]
     @State private var searchText: String = ""
     @State private var showAddProductSheet = false
-    @State private var selectedProduct: DetailedProductModel? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -33,7 +33,8 @@ struct InventoryScreenView: View {
             .environmentObject(authService)
         }
         .sheet(item: $selectedProduct) { product in
-            ProductDetailSheet(product: product)
+            ProductDetailView(product: product)
+                .environmentObject(localization)
         }
         .navigationBarBackButtonHidden(true)
         .onChange(of: showAddProductSheet) { isPresented in
@@ -64,8 +65,10 @@ struct InventoryScreenView: View {
     }
 
     private var productList: some View {
-        InventoryGroupView()
-            .navigationBarBackButtonHidden(true)
+        InventoryGroupView { product in
+            selectedProduct = product
+        }
+        .navigationBarBackButtonHidden(true)
     }
 
     private var addButton: some View {

--- a/NexStock1.0/View/ProductDetailSheet.swift
+++ b/NexStock1.0/View/ProductDetailSheet.swift
@@ -34,19 +34,19 @@ struct ProductDetailSheet: View {
                             .font(.title2.bold())
 
                         if let stock = details.stock_actual {
-                            Text("Stock actual: \(stock)")
+                            Text("\("current_stock".localized): \(stock)")
                         }
                         if let date = details.expiration_date {
                             Text("Expira: \(date)")
                         }
                         if let min = details.stock_minimum {
-                            Text("Mínimo: \(min)")
+                            Text("\("minimum_stock".localized): \(min)")
                         }
                         if let max = details.stock_maximum {
-                            Text("Máximo: \(max)")
+                            Text("\("maximum_stock".localized): \(max)")
                         }
                         if let sensor = details.sensor_type {
-                            Text("Sensor: \(sensor)")
+                            Text("Sensor: \(sensor.localized)")
                         }
                     }
                     .padding()
@@ -55,7 +55,7 @@ struct ProductDetailSheet: View {
                         .foregroundColor(.red)
                 }
             }
-            .navigationTitle("Detalle")
+            .navigationTitle("information".localized)
             .onAppear(perform: fetchDetails)
         }
     }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct ProductDetailView: View {
+    let product: ProductModel
+    @StateObject private var viewModel = ProductDetailViewModel()
+    @EnvironmentObject var localization: LocalizationManager
+    @Environment(\.dismiss) var dismiss
+    @State private var selectedTab = 0
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Picker("", selection: $selectedTab) {
+                    Text("information".localized).tag(0)
+                    Text("movements".localized).tag(1)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .padding()
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .padding()
+                } else if selectedTab == 0 {
+                    infoView
+                } else {
+                    movementsView
+                }
+            }
+            .navigationTitle(product.name.localized)
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear { viewModel.fetch(id: product.id) }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Close", action: { dismiss() }) }
+            }
+        }
+    }
+
+    private var infoView: some View {
+        ScrollView {
+            if let detail = viewModel.detail {
+                VStack(spacing: 12) {
+                    if let url = URL(string: detail.image_url) {
+                        AsyncImage(url: url) { image in
+                            image.resizable()
+                        } placeholder: {
+                            ProgressView()
+                        }
+                        .frame(width: 150, height: 150)
+                        .cornerRadius(8)
+                    }
+
+                    Text(detail.name.localized)
+                        .font(.title2.bold())
+                    Text("\("current_stock".localized): \(detail.stock_actual)")
+                    Text("\("minimum_stock".localized): \(detail.stock_min)")
+                    Text("\("maximum_stock".localized): \(detail.stock_max)")
+                    Text("\("brand".localized): \(detail.brand)")
+                    Text("\("last_updated".localized): \(detail.updated_at)")
+                    Text("\("description".localized): \(detail.description)")
+                }
+                .padding()
+            }
+        }
+    }
+
+    private var movementsView: some View {
+        List {
+            if viewModel.movements.isEmpty {
+                Text("no_movements".localized)
+            } else {
+                ForEach(viewModel.movements) { move in
+                    VStack(alignment: .leading) {
+                        Text(move.created_at)
+                            .font(.caption)
+                        Text("\(move.type.localized) - \(move.quantity)")
+                        Text(move.user)
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ProductDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductDetailView(product: ProductModel(id: "1", name: "Apple", image_url: "", stock_actual: 0, category: "Alimentos", sensor_type: "temperature"))
+            .environmentObject(LocalizationManager())
+    }
+}

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class ProductDetailViewModel: ObservableObject {
+    @Published var detail: ProductDetailInfo?
+    @Published var movements: [ProductMovement] = []
+    @Published var isLoading = false
+
+    func fetch(id: String) {
+        guard !isLoading else { return }
+        isLoading = true
+        ProductService.shared.fetchProductDetail(id: id) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isLoading = false
+                switch result {
+                case .success(let response):
+                    self.detail = response.product
+                    self.movements = response.movements
+                case .failure(let error):
+                    print("Failed to load detail", error)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add models for product detail and movements
- fetch product details from API
- show modal with info/movements tabs
- support product taps from inventory screen
- localize category, sensor and new labels across languages

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b09ee01d48327a308de9961a3d1fc