### PR TITLE
Fix product detail modal

### DIFF
--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -9,13 +9,13 @@ struct ProductDetailResponse: Codable {
 struct ProductDetailInfo: Identifiable, Codable {
     let id: Int
     let name: String
-    let brand: String
-    let description: String
-    let image_url: String
-    let stock_actual: Int
-    let stock_min: Int
-    let stock_max: Int
-    let updated_at: String
+    let brand: String?
+    let description: String?
+    let image_url: String?
+    let stock_actual: Int?
+    let stock_min: Int?
+    let stock_max: Int?
+    let updated_at: String?
 }
 
 struct ProductMovement: Identifiable, Codable {

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -91,6 +91,9 @@ class ProductService {
 
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data {
+                if let jsonString = String(data: data, encoding: .utf8) {
+                    print("🧾 Detail JSON: \(jsonString)")
+                }
                 do {
                     let decoded = try JSONDecoder().decode(ProductDetailResponse.self, from: data)
                     completion(.success(decoded))

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -20,6 +20,10 @@ struct ProductDetailView: View {
                 if viewModel.isLoading {
                     ProgressView()
                         .padding()
+                } else if let error = viewModel.errorMessage {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .padding()
                 } else if selectedTab == 0 {
                     infoView
                 } else {
@@ -39,7 +43,7 @@ struct ProductDetailView: View {
         ScrollView {
             if let detail = viewModel.detail {
                 VStack(spacing: 12) {
-                    if let url = URL(string: detail.image_url) {
+                    if let urlString = detail.image_url, let url = URL(string: urlString) {
                         AsyncImage(url: url) { image in
                             image.resizable()
                         } placeholder: {
@@ -51,12 +55,12 @@ struct ProductDetailView: View {
 
                     Text(detail.name.localized)
                         .font(.title2.bold())
-                    Text("\("current_stock".localized): \(detail.stock_actual)")
-                    Text("\("minimum_stock".localized): \(detail.stock_min)")
-                    Text("\("maximum_stock".localized): \(detail.stock_max)")
-                    Text("\("brand".localized): \(detail.brand)")
-                    Text("\("last_updated".localized): \(detail.updated_at)")
-                    Text("\("description".localized): \(detail.description)")
+                    Text("\("current_stock".localized): \(detail.stock_actual ?? 0)")
+                    Text("\("minimum_stock".localized): \(detail.stock_min ?? 0)")
+                    Text("\("maximum_stock".localized): \(detail.stock_max ?? 0)")
+                    Text("\("brand".localized): \(detail.brand ?? "N/A")")
+                    Text("\("last_updated".localized): \(detail.updated_at ?? "N/A")")
+                    Text("\("description".localized): \(detail.description ?? "Sin descripción")")
                 }
                 .padding()
             }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -4,6 +4,7 @@ class ProductDetailViewModel: ObservableObject {
     @Published var detail: ProductDetailInfo?
     @Published var movements: [ProductMovement] = []
     @Published var isLoading = false
+    @Published var errorMessage: String?
 
     func fetch(id: String) {
         guard !isLoading else { return }
@@ -16,8 +17,10 @@ class ProductDetailViewModel: ObservableObject {
                 case .success(let response):
                     self.detail = response.product
                     self.movements = response.movements
+                    print("Product detail loaded", response)
                 case .failure(let error):
                     print("Failed to load detail", error)
+                    self.errorMessage = error.localizedDescription
                 }
             }
         }


### PR DESCRIPTION
## Summary
- make `ProductDetailInfo` properties optional so the view handles missing fields
- expose errors in `ProductDetailViewModel` and log results
- print received JSON in `ProductService` for debugging
- display default text when product detail values are absent
- show errors in the product detail view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b0d106a108327b6614386d0b3ed43