### PR TITLE
Implement product movements tab

### DIFF
--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -19,10 +19,21 @@ struct ProductDetailInfo: Identifiable, Codable {
     let updated_at: String?
 }
 
+/// Represents a single stock movement for a product
 struct ProductMovement: Identifiable, Codable {
-    let id: Int
+    /// Some older endpoints may include an id field
+    let identifier: Int?
+    let date: String?
+    let time: String?
     let type: String
+    let stock_before: Int?
     let quantity: Int
-    let user: String
-    let created_at: String
+    let stock_after: Int?
+    let comment: String?
+
+    // Fields kept for backwards compatibility with previous endpoints
+    let user: String?
+    let created_at: String?
+
+    var id: Int { identifier ?? Int(Date().timeIntervalSince1970) }
 }

--- a/NexStock1.0/Models/ProductMovementsResponse.swift
+++ b/NexStock1.0/Models/ProductMovementsResponse.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct ProductMovementsResponse: Codable {
+    let message: String?
+    let movements: [ProductMovement]
+}

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -105,4 +105,22 @@ class ProductService {
             }
         }.resume()
     }
+
+    /// Fetch only the movement history for a product
+    func fetchProductMovements(id: String, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/" + id + "/movements") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(ProductMovementsResponse.self, from: data)
+                    completion(.success(decoded.movements))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
 }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -68,19 +68,45 @@ struct ProductDetailView: View {
     }
 
     private var movementsView: some View {
-        List {
+        ScrollView {
             if viewModel.movements.isEmpty {
                 Text("no_movements".localized)
+                    .padding()
             } else {
-                ForEach(viewModel.movements) { move in
-                    VStack(alignment: .leading) {
-                        Text(move.created_at)
-                            .font(.caption)
-                        Text("\(move.type.localized) - \(move.quantity)")
-                        Text(move.user)
-                            .font(.caption2)
+                VStack(spacing: 12) {
+                    ForEach(viewModel.movements) { move in
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let date = move.date, let time = move.time {
+                                Text("\(date) \(time)")
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            } else if let created = move.created_at {
+                                Text(created)
+                                    .font(.caption)
+                                    .foregroundColor(.gray)
+                            }
+
+                            Text("\(move.type.localized) - \(move.quantity)")
+                                .font(.subheadline.bold())
+
+                            if let comment = move.comment, !comment.isEmpty {
+                                Text(comment)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                            if let user = move.user {
+                                Text(user)
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.secondaryColor)
+                        .cornerRadius(10)
                     }
                 }
+                .padding(.horizontal)
             }
         }
     }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -9,18 +9,35 @@ class ProductDetailViewModel: ObservableObject {
     func fetch(id: String) {
         guard !isLoading else { return }
         isLoading = true
+
         ProductService.shared.fetchProductDetail(id: id) { [weak self] result in
             DispatchQueue.main.async {
                 guard let self = self else { return }
-                self.isLoading = false
+
                 switch result {
                 case .success(let response):
                     self.detail = response.product
-                    // If the backend doesn't provide movements we default to an empty list
-                    self.movements = response.movements ?? []
+                    self.fetchMovements(id: id)
                     print("Product detail loaded", response)
                 case .failure(let error):
+                    self.isLoading = false
                     print("Failed to load detail", error)
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func fetchMovements(id: String) {
+        ProductService.shared.fetchProductMovements(id: id) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isLoading = false
+
+                switch result {
+                case .success(let movements):
+                    self.movements = movements
+                case .failure(let error):
                     self.errorMessage = error.localizedDescription
                 }
             }


### PR DESCRIPTION
## Summary
- add ProductMovementsResponse model
- query new `/movements` endpoint to get movement history
- update ProductMovement model to support new endpoint fields
- refresh ProductDetailViewModel to load movements separately
- style movements list to match the rest of the app

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b1577f49483278c3d868a16445d9e