### PR TITLE
Improve visual style for product screens

### DIFF
--- a/NexStock1.0/View/AddProductSheet.swift
+++ b/NexStock1.0/View/AddProductSheet.swift
@@ -53,90 +53,138 @@ struct AddProductSheet: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                // Sección 1
-                Section(header: Text("information".localized)) {
-                    TextField("Nombre", text: $name)
-                    TextField("Marca", text: $brand)
-                    TextField("Descripción", text: $description)
-                }
-
-                // Sección 2
-                Section(header: Text("stock".localized)) {
-                    HStack {
-                        Text("Mínimo:")
-                        TextField("0", value: $stockMin, format: .number)
-                            .keyboardType(.numberPad)
-                            .textFieldStyle(.roundedBorder)
-                        Stepper("", value: $stockMin, in: 0...100)
-                            .labelsHidden()
-                    }
-
-                    HStack {
-                        Text("Máximo:")
-                        TextField("0", value: $stockMax, format: .number)
-                            .keyboardType(.numberPad)
-                            .textFieldStyle(.roundedBorder)
-                        Stepper("", value: $stockMax, in: 1...200)
-                            .labelsHidden()
-                    }
-                }
-
-                // Sección 3
-                Section(header: Text("image".localized)) {
-                    if let image = selectedImage {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(height: 150)
-                    } else if isUploading {
-                        ProgressView("Subiendo imagen...")
-                    } else {
-                        Text("No hay imagen seleccionada")
-                    }
-
-                    Button("Subir desde galería o cámara") {
-                        showImageSourceOptions = true
-                    }
-                    .confirmationDialog("Selecciona origen de la imagen", isPresented: $showImageSourceOptions) {
-                        Button("Tomar foto") {
-                            sourceType = .camera
-                            showImagePicker = true
+            ZStack {
+                Color.backColor.ignoresSafeArea()
+                ScrollView {
+                    VStack(spacing: 20) {
+                        // Sección 1
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("information".localized)
+                                .font(.headline)
+                            TextField("Nombre", text: $name)
+                                .textFieldStyle(.roundedBorder)
+                            TextField("Marca", text: $brand)
+                                .textFieldStyle(.roundedBorder)
+                            TextField("Descripción", text: $description)
+                                .textFieldStyle(.roundedBorder)
                         }
-                        Button("Seleccionar de galería") {
-                            sourceType = .photoLibrary
-                            showImagePicker = true
-                        }
-                        Button("Cancelar", role: .cancel) {}
-                    }
-                }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
 
-                // Sección 4
-                Section(header: Text("category".localized)) {
-                    Picker("Categoría", selection: $selectedCategory) {
-                        ForEach(categories, id: \.self) { category in
-                            Text(category.name.localized).tag(category as Category?)
+                        // Sección 2
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("stock".localized)
+                                .font(.headline)
+                            HStack {
+                                Text("Mínimo:")
+                                TextField("0", value: $stockMin, format: .number)
+                                    .keyboardType(.numberPad)
+                                    .textFieldStyle(.roundedBorder)
+                                Stepper("", value: $stockMin, in: 0...100)
+                                    .labelsHidden()
+                            }
+                            HStack {
+                                Text("Máximo:")
+                                TextField("0", value: $stockMax, format: .number)
+                                    .keyboardType(.numberPad)
+                                    .textFieldStyle(.roundedBorder)
+                                Stepper("", value: $stockMax, in: 1...200)
+                                    .labelsHidden()
+                            }
                         }
-                    }
-                }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
 
-                // Sección 5
-                Section(header: Text("unit".localized)) {
-                    Picker("Tipo de unidad", selection: $selectedUnitType) {
-                        ForEach(unitTypes, id: \.self) { unit in
-                            Text(unit.name.localized).tag(unit as UnitType?)
-                        }
-                    }
-                }
+                        // Sección 3
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("image".localized)
+                                .font(.headline)
+                            if let image = selectedImage {
+                                Image(uiImage: image)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(height: 150)
+                            } else if isUploading {
+                                ProgressView("Subiendo imagen...")
+                            } else {
+                                Text("No hay imagen seleccionada")
+                                    .font(.footnote)
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                            }
 
-                // Sección 6 - Método de entrada
-                Section(header: Text("input_method".localized)) {
-                    Picker("input_method".localized, selection: $inputMethod) {
-                        ForEach(InputMethod.allCases, id: \.self) { method in
-                            Text(method.rawValue.localized).tag(method)
+                            Button("Subir desde galería o cámara") {
+                                showImageSourceOptions = true
+                            }
+                            .confirmationDialog("Selecciona origen de la imagen", isPresented: $showImageSourceOptions) {
+                                Button("Tomar foto") {
+                                    sourceType = .camera
+                                    showImagePicker = true
+                                }
+                                Button("Seleccionar de galería") {
+                                    sourceType = .photoLibrary
+                                    showImagePicker = true
+                                }
+                                Button("Cancelar", role: .cancel) {}
+                            }
                         }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
+
+                        // Sección 4
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("category".localized)
+                                .font(.headline)
+                            Picker("Categoría", selection: $selectedCategory) {
+                                ForEach(categories, id: \.self) { category in
+                                    Text(category.name.localized).tag(category as Category?)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                        }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
+
+                        // Sección 5
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("unit".localized)
+                                .font(.headline)
+                            Picker("Tipo de unidad", selection: $selectedUnitType) {
+                                ForEach(unitTypes, id: \.self) { unit in
+                                    Text(unit.name.localized).tag(unit as UnitType?)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                        }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
+
+                        // Sección 6 - Método de entrada
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("input_method".localized)
+                                .font(.headline)
+                            Picker("input_method".localized, selection: $inputMethod) {
+                                ForEach(InputMethod.allCases, id: \.self) { method in
+                                    Text(method.rawValue.localized).tag(method)
+                                }
+                            }
+                            .pickerStyle(SegmentedPickerStyle())
+                        }
+                        .padding()
+                        .background(Color.secondaryColor)
+                        .cornerRadius(12)
+                        .shadow(radius: 2)
                     }
-                    .pickerStyle(SegmentedPickerStyle())
+                    .padding()
                 }
             }
             .navigationTitle("new_product".localized)

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -9,10 +9,12 @@ struct ProductDetailView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 16) {
-                Picker("", selection: $selectedTab) {
-                    Text("information".localized).tag(0)
-                    Text("movements".localized).tag(1)
+            ZStack {
+                Color.backColor.ignoresSafeArea()
+                VStack(spacing: 16) {
+                    Picker("", selection: $selectedTab) {
+                        Text("information".localized).tag(0)
+                        Text("movements".localized).tag(1)
                 }
                 .pickerStyle(SegmentedPickerStyle())
                 .padding(.horizontal)
@@ -29,8 +31,9 @@ struct ProductDetailView: View {
                 } else {
                     movementsView
                 }
+                }
+                .padding(.top)
             }
-            .padding(.top)
             .navigationTitle(product.name.localized)
             .navigationBarTitleDisplayMode(.inline)
             .onAppear { viewModel.fetch(id: product.id) }
@@ -63,14 +66,20 @@ struct ProductDetailView: View {
 
                     let critical = (detail.stock_actual ?? 0) <= (detail.stock_min ?? Int.min)
                     Text("\("current_stock".localized): \(detail.stock_actual.map(String.init) ?? "no_information".localized)")
+                        .font(.body)
                         .fontWeight(critical ? .bold : .regular)
                         .foregroundColor(critical ? .red : .primary)
 
                     Text("\("minimum_stock".localized): \(detail.stock_min.map(String.init) ?? "no_information".localized)")
+                        .font(.body)
                     Text("\("maximum_stock".localized): \(detail.stock_max.map(String.init) ?? "no_information".localized)")
+                        .font(.body)
                     Text("\("brand".localized): \(detail.brand?.isEmpty == false ? detail.brand! : "no_information".localized)")
+                        .font(.body)
                     Text("\("last_updated".localized): \(formattedDate(detail.updated_at))")
+                        .font(.footnote)
                     Text("\("description".localized): \((detail.description?.isEmpty == false ? detail.description! : "no_information".localized))")
+                        .font(.body)
                         .multilineTextAlignment(.leading)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -135,16 +144,16 @@ struct ProductDetailView: View {
         var body: some View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(formattedDate())
-                    .font(.caption)
+                    .font(.footnote)
                     .foregroundColor(.gray)
 
                 HStack {
                     Text(move.type.localized)
-                        .font(.subheadline.bold())
+                        .font(.body.bold())
                         .foregroundColor(isDecrease ? .red : .green)
                     Spacer()
                     Text("\(diff > 0 ? "+" : "")\(move.quantity)")
-                        .font(.subheadline.bold())
+                        .font(.body.bold())
                 }
 
                 HStack {
@@ -152,17 +161,17 @@ struct ProductDetailView: View {
                     Spacer()
                     Text("\("after".localized): \(move.stock_after.map(String.init) ?? "no_information".localized)")
                 }
-                .font(.caption)
+                .font(.footnote)
 
                 if let comment = move.comment, !comment.isEmpty {
                     Text(comment)
-                        .font(.caption2)
+                        .font(.footnote)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
                 }
                 if let user = move.user {
                     Text(user)
-                        .font(.caption2)
+                        .font(.footnote)
                         .foregroundColor(.secondary)
                 }
             }


### PR DESCRIPTION
## Summary
- apply backColor background and card style in ProductDetailView
- unify font sizes for product details and movements
- redesign AddProductSheet with consistent card sections and colors

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d9100c88327a3dc85def5e0ed64