### PR TITLE
Use theme colors in product modals

### DIFF
--- a/NexStock1.0/View/AddProductSheet.swift
+++ b/NexStock1.0/View/AddProductSheet.swift
@@ -54,7 +54,7 @@ struct AddProductSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.backColor.ignoresSafeArea()
+                Color.primaryColor.ignoresSafeArea()
                 ScrollView {
                     VStack(spacing: 20) {
                         // Sección 1
@@ -149,6 +149,7 @@ struct AddProductSheet: View {
                         }
                     }
                     .padding()
+                    .foregroundColor(.tertiaryColor)
                 }
                 .scrollContentBackground(.hidden)
             }

--- a/NexStock1.0/View/ProductDetailSheet.swift
+++ b/NexStock1.0/View/ProductDetailSheet.swift
@@ -9,7 +9,7 @@ struct ProductDetailSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.backColor.ignoresSafeArea()
+                Color.primaryColor.ignoresSafeArea()
                 Group {
                     if isLoading {
                         ProgressView()
@@ -50,11 +50,12 @@ struct ProductDetailSheet: View {
                         if let sensor = details.sensor_type {
                             Text("Sensor: \(sensor.localized)")
                         }
-                    }
+                        }
                         .padding()
+                        .foregroundColor(.tertiaryColor)
                     } else if let message = errorMessage {
                         Text(message)
-                            .foregroundColor(.red)
+                            .foregroundColor(.tertiaryColor)
                     }
                 }
             }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -10,7 +10,7 @@ struct ProductDetailView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.backColor.ignoresSafeArea()
+                Color.primaryColor.ignoresSafeArea()
                 VStack(spacing: 16) {
                     Picker("", selection: $selectedTab) {
                         Text("information".localized).tag(0)
@@ -24,7 +24,7 @@ struct ProductDetailView: View {
                         .padding()
                 } else if let error = viewModel.errorMessage {
                     Text(error)
-                        .foregroundColor(.red)
+                        .foregroundColor(.tertiaryColor)
                         .padding()
                 } else if selectedTab == 0 {
                     infoView
@@ -68,7 +68,7 @@ struct ProductDetailView: View {
                     Text("\("current_stock".localized): \(detail.stock_actual.map(String.init) ?? "no_information".localized)")
                         .font(.body)
                         .fontWeight(critical ? .bold : .regular)
-                        .foregroundColor(critical ? .red : .primary)
+                        .foregroundColor(.tertiaryColor)
 
                     Text("\("minimum_stock".localized): \(detail.stock_min.map(String.init) ?? "no_information".localized)")
                         .font(.body)
@@ -91,6 +91,7 @@ struct ProductDetailView: View {
             }
         }
         .scrollContentBackground(.hidden)
+        .foregroundColor(.tertiaryColor)
     }
 
     private var movementsView: some View {
@@ -112,6 +113,7 @@ struct ProductDetailView: View {
             }
         }
         .scrollContentBackground(.hidden)
+        .foregroundColor(.tertiaryColor)
     }
 
     private func formattedDate(_ string: String?) -> String {
@@ -147,12 +149,12 @@ struct ProductDetailView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(formattedDate())
                     .font(.footnote)
-                    .foregroundColor(.gray)
+                    .foregroundColor(.tertiaryColor.opacity(0.7))
 
                 HStack {
                     Text(move.type.localized)
                         .font(.body.bold())
-                        .foregroundColor(isDecrease ? .red : .green)
+                        .foregroundColor(.tertiaryColor)
                     Spacer()
                     Text("\(diff > 0 ? "+" : "")\(move.quantity)")
                         .font(.body.bold())
@@ -168,13 +170,13 @@ struct ProductDetailView: View {
                 if let comment = move.comment, !comment.isEmpty {
                     Text(comment)
                         .font(.footnote)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(.tertiaryColor.opacity(0.7))
                         .multilineTextAlignment(.leading)
                 }
                 if let user = move.user {
                     Text(user)
                         .font(.footnote)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(.tertiaryColor.opacity(0.7))
                 }
             }
             .padding()

--- a/NexStock1.0/View/SectionContainer.swift
+++ b/NexStock1.0/View/SectionContainer.swift
@@ -141,7 +141,7 @@ struct SettingsTile: View {
         .padding(EdgeInsets(top: 20, leading: 10, bottom: 20, trailing: 10))
         .background(Color.secondaryColor)
         .cornerRadius(15)
-        .shadow(color: Color.black.opacity(0.05), radius: 5, x: 0, y: 2)
+        .shadow(color: Color.primaryColor.opacity(0.05), radius: 5, x: 0, y: 2)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(title))
         .accessibilityHint("Presiona para acceder a \(title.lowercased())")


### PR DESCRIPTION
## Summary
- use `Color.primaryColor` as base background for product sheets and detail view
- tint text with `Color.tertiaryColor`
- update movement rows and info sections to rely on theme colors
- align shadows to use theme primary color

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b292ad7a4832788e294ff2c17c2e7