### PR TITLE
Add search bar with debounced network results

### DIFF
--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct SearchResultResponse: Codable {
+    let message: String
+    let total: Int
+    let results: [SearchProduct]
+}
+
+struct SearchProduct: Codable, Identifiable {
+    var id: UUID { UUID() }
+    let name: String
+    let image_url: String
+    let stock_actual: Int
+    let category: String
+    let sensor_type: String
+}

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -124,7 +124,7 @@ class ProductService {
         }.resume()
     }
 
-    func searchProducts(name: String, limit: Int = 20, offset: Int = 0, completion: @escaping (Result<[ProductModel], Error>) -> Void) {
+    func searchProducts(name: String, limit: Int = 20, offset: Int = 0, completion: @escaping (Result<[SearchProduct], Error>) -> Void) {
         var components = URLComponents(string: baseURL + "/search")
         components?.queryItems = [
             URLQueryItem(name: "name", value: name),
@@ -140,8 +140,8 @@ class ProductService {
                     print("🧾 Search JSON: \(jsonString)")
                 }
                 do {
-                    let decoded = try JSONDecoder().decode(ProductResponse.self, from: data)
-                    completion(.success(decoded.products))
+                    let decoded = try JSONDecoder().decode(SearchResultResponse.self, from: data)
+                    completion(.success(decoded.results))
                 } catch {
                     completion(.failure(error))
                 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -94,11 +94,14 @@ struct InventoryScreenView: View {
                     if searchVM.isLoading {
                         ProgressView()
                             .padding()
+                    } else if searchVM.results.isEmpty {
+                        Text("No se encontraron productos")
+                            .foregroundColor(.tertiaryColor)
+                            .padding()
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                ProductCard(product: product) {
-                                    selectedProduct = product
+                                SearchProductCardView(product: product) {
                                     isSearchFocused = false
                                 }
                             }

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct SearchProductCardView: View {
+    let product: SearchProduct
+    var onTap: () -> Void = {}
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let url = URL(string: product.image_url) {
+                AsyncImage(url: url) { image in
+                    image.resizable()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 120, height: 120)
+                .cornerRadius(8)
+            }
+            Text(product.name.localized)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+            Text("Stock: \(product.stock_actual)")
+                .font(.caption)
+                .foregroundColor(.tertiaryColor)
+            Text("Sensor: \(product.sensor_type.localized)")
+                .font(.caption)
+                .foregroundColor(.tertiaryColor)
+        }
+        .padding()
+        .background(Color.secondaryColor)
+        .cornerRadius(12)
+        .onTapGesture { onTap() }
+    }
+}
+
+#Preview {
+    SearchProductCardView(product: SearchProduct(name: "Ejemplo", image_url: "", stock_actual: 0, category: "", sensor_type: "manual"))
+        .environmentObject(ThemeManager())
+        .environmentObject(LocalizationManager())
+}

--- a/NexStock1.0/ViewModels/ProductSearchViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductSearchViewModel.swift
@@ -3,7 +3,7 @@ import Combine
 
 class ProductSearchViewModel: ObservableObject {
     @Published var query: String = ""
-    @Published var results: [ProductModel] = []
+    @Published var results: [SearchProduct] = []
     @Published var isLoading: Bool = false
 
     private var cancellables = Set<AnyCancellable>()


### PR DESCRIPTION
## Summary
- decode search results with new `SearchResultResponse` and `SearchProduct` models
- update product search service and view model to use new types
- display results in `SearchProductCardView` and show empty state message
- keep search bar highlighting and background dimming when focused

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b4c4ec5dc832786ad85a2a63cdbae