### PR TITLE
Fix search product cards with category

### DIFF
--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -7,7 +7,9 @@ struct SearchResultResponse: Codable {
 }
 
 struct SearchProduct: Codable, Identifiable {
-    var id: UUID { UUID() }
+    /// A stable identifier generated on initialization since the
+    /// backend search endpoint does not provide one.
+    let id: UUID = UUID()
     let name: String
     let image_url: String
     let stock_actual: Int

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -15,12 +15,19 @@ struct SearchProductCardView: View {
                 .frame(width: 120, height: 120)
                 .cornerRadius(8)
             }
+
             Text(product.name.localized)
                 .font(.headline)
                 .foregroundColor(.tertiaryColor)
+
+            Text(product.category.localized)
+                .font(.subheadline)
+                .foregroundColor(.tertiaryColor)
+
             Text("Stock: \(product.stock_actual)")
                 .font(.caption)
                 .foregroundColor(.tertiaryColor)
+
             Text("Sensor: \(product.sensor_type.localized)")
                 .font(.caption)
                 .foregroundColor(.tertiaryColor)


### PR DESCRIPTION
## Summary
- show product category in search result cards
- generate a stable identifier for each `SearchProduct`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b4f10a1948327bd4b1b782a3494e9