### PR TITLE
Add global product detail modal

### DIFF
--- a/NexStock1.0/View/AppView.swift
+++ b/NexStock1.0/View/AppView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AppView: View {
     @State private var path = NavigationPath()
     @State private var showMenu = false // ✅ AGREGA ESTA LÍNEA
+    @StateObject private var detailPresenter = ProductDetailPresenter()
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -43,6 +44,11 @@ struct AppView: View {
                         AlertView(path: $path)
                     }
                 }
+        }
+        .environmentObject(detailPresenter)
+        .sheet(item: $detailPresenter.selectedProduct) { info in
+            ProductDetailView(product: info)
+                .environmentObject(localization)
         }
     }
 }

--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -4,6 +4,7 @@ struct HomeInventoryCardView: View {
     let product: InventoryProduct
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         VStack(spacing: 8) {
@@ -25,5 +26,8 @@ struct HomeInventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture {
+            detailPresenter.present(id: product.name, name: product.name)
+        }
     }
 }

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct InventoryCardView: View {
     let product: DetailedProductModel
     var onTap: (() -> Void)? = nil
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -44,6 +45,7 @@ struct InventoryCardView: View {
         .cornerRadius(12)
         .shadow(radius: 2)
         .onTapGesture {
+            detailPresenter.present(id: String(product.id), name: product.name)
             onTap?()
         }
     }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
-    var onProductTap: (ProductModel) -> Void = { _ in }
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         ScrollView {
@@ -16,9 +16,10 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        ProductCard(product: product) {
-                                            onProductTap(product)
-                                        }
+                                        ProductCard(product: product)
+                                            .onTapGesture {
+                                                detailPresenter.present(id: product.id, name: product.name)
+                                            }
                                         .onAppear {
                                             viewModel.loadMoreIfNeeded(currentItem: product, category: category)
                                         }
@@ -39,7 +40,6 @@ struct InventoryGroupView: View {
 
 struct ProductCard: View {
     let product: ProductModel
-    var onTap: () -> Void = {}
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -62,7 +62,6 @@ struct ProductCard: View {
         .padding()
         .background(Color.secondaryColor)
         .cornerRadius(12)
-        .onTapGesture { onTap() }
     }
 }
 
@@ -71,5 +70,6 @@ struct InventoryGroupView_Previews: PreviewProvider {
         InventoryGroupView()
             .environmentObject(ThemeManager())
             .environmentObject(LocalizationManager())
+            .environmentObject(ProductDetailPresenter())
     }
 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -20,7 +20,7 @@ struct InventoryScreenView: View {
     @StateObject private var searchVM = ProductSearchViewModel()
     @FocusState private var isSearchFocused: Bool
     @State private var showAddProductSheet = false
-    @State private var selectedProduct: ProductModel? = nil
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -42,10 +42,6 @@ struct InventoryScreenView: View {
                 showAddProductSheet = false
             }
             .environmentObject(authService)
-        }
-        .sheet(item: $selectedProduct) { product in
-            ProductDetailView(product: product)
-                .environmentObject(localization)
         }
         .navigationBarBackButtonHidden(true)
         .onChange(of: showAddProductSheet) { isPresented in
@@ -86,9 +82,7 @@ struct InventoryScreenView: View {
     private var productList: some View {
         Group {
             if searchVM.query.isEmpty {
-                InventoryGroupView { product in
-                    selectedProduct = product
-                }
+                InventoryGroupView()
             } else {
                 ScrollView {
                     if searchVM.isLoading {
@@ -103,6 +97,9 @@ struct InventoryScreenView: View {
                             ForEach(searchVM.results) { product in
                                 SearchProductCardView(product: product) {
                                     isSearchFocused = false
+                                }
+                                .onTapGesture {
+                                    detailPresenter.present(id: product.name, name: product.name)
                                 }
                             }
                         }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ProductDetailView: View {
-    let product: ProductModel
+    let product: ProductIdentifier
     @StateObject private var viewModel = ProductDetailViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @Environment(\.dismiss) var dismiss
@@ -203,7 +203,7 @@ struct ProductDetailView: View {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailView(product: ProductModel(id: "1", name: "Apple", image_url: "", stock_actual: 0, category: "Alimentos", sensor_type: "temperature"))
+        ProductDetailView(product: ProductIdentifier(id: "1", name: "Apple"))
             .environmentObject(LocalizationManager())
     }
 }

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SearchProductCardView: View {
     let product: SearchProduct
     var onTap: () -> Void = {}
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -35,7 +36,10 @@ struct SearchProductCardView: View {
         .padding()
         .background(Color.secondaryColor)
         .cornerRadius(12)
-        .onTapGesture { onTap() }
+        .onTapGesture {
+            detailPresenter.present(id: product.name, name: product.name)
+            onTap()
+        }
     }
 }
 
@@ -43,4 +47,5 @@ struct SearchProductCardView: View {
     SearchProductCardView(product: SearchProduct(name: "Ejemplo", image_url: "", stock_actual: 0, category: "", sensor_type: "manual"))
         .environmentObject(ThemeManager())
         .environmentObject(LocalizationManager())
+        .environmentObject(ProductDetailPresenter())
 }

--- a/NexStock1.0/ViewModels/ProductDetailPresenter.swift
+++ b/NexStock1.0/ViewModels/ProductDetailPresenter.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftUI
+
+/// Simple identifier used to present product details from any view.
+struct ProductIdentifier: Identifiable, Equatable {
+    let id: String
+    let name: String
+}
+
+/// Global presenter for the product detail sheet.
+final class ProductDetailPresenter: ObservableObject {
+    @Published var selectedProduct: ProductIdentifier?
+
+    /// Convenience method to present a product by id and name
+    func present(id: String, name: String) {
+        selectedProduct = ProductIdentifier(id: id, name: name)
+    }
+}


### PR DESCRIPTION
## Summary
- extract reusable `ProductDetailPresenter`
- show `ProductDetailView` from `AppView` as global sheet
- open product detail when tapping any product card across the app

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b51d088288327af9cbc8cce22c1c9