### PR TITLE
Fix product detail modal with correct product IDs

### DIFF
--- a/NexStock1.0/Models/InventoryDetailModel.swift
+++ b/NexStock1.0/Models/InventoryDetailModel.swift
@@ -11,7 +11,8 @@ struct InventoryHomeResponse: Codable {
 }
 
 struct InventoryProduct: Identifiable, Codable {
-    let id = UUID()
+    /// Identifier provided by backend home summary endpoint
+    let id: Int
     let name: String
     let stock_actual: Int?
     let expiration_date: String?

--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -8,7 +8,8 @@ struct ProductDetailResponse: Codable {
 }
 
 struct ProductDetailInfo: Identifiable, Codable {
-    let id: String
+    /// Backend identifier of the product
+    let id: Int
     let name: String
     let brand: String?
     let description: String?

--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -7,9 +7,8 @@ struct SearchResultResponse: Codable {
 }
 
 struct SearchProduct: Codable, Identifiable {
-    /// A stable identifier generated on initialization since the
-    /// backend search endpoint does not provide one.
-    let id: UUID = UUID()
+    /// Unique identifier of the product returned by the backend
+    let id: Int
     let name: String
     let image_url: String
     let stock_actual: Int

--- a/NexStock1.0/Models/SimpleProductModel.swift
+++ b/NexStock1.0/Models/SimpleProductModel.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 struct ProductModel: Identifiable, Codable {
-    let id: String
+    /// Identifier provided by the backend
+    let id: Int
     let name: String
     let image_url: String
     let stock_actual: Int

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -86,8 +86,10 @@ class ProductService {
         }.resume()
     }
 
-    func fetchProductDetail(id: String, completion: @escaping (Result<ProductDetailResponse, Error>) -> Void) {
-        guard let url = URL(string: baseURL + "/" + id) else { return }
+    func fetchProductDetail(id: Int, completion: @escaping (Result<ProductDetailResponse, Error>) -> Void) {
+        var components = URLComponents(string: baseURL + "/detail")
+        components?.queryItems = [URLQueryItem(name: "id", value: String(id))]
+        guard let url = components?.url else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data {
@@ -107,8 +109,8 @@ class ProductService {
     }
 
     /// Fetch only the movement history for a product
-    func fetchProductMovements(id: String, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
-        guard let url = URL(string: baseURL + "/" + id + "/movements") else { return }
+    func fetchProductMovements(id: Int, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/" + String(id) + "/movements") else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data {

--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -27,7 +27,7 @@ struct HomeInventoryCardView: View {
         .cornerRadius(12)
         .shadow(radius: 2)
         .onTapGesture {
-            detailPresenter.present(id: product.name, name: product.name)
+            detailPresenter.present(id: product.id, name: product.name)
         }
     }
 }

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -45,7 +45,7 @@ struct InventoryCardView: View {
         .cornerRadius(12)
         .shadow(radius: 2)
         .onTapGesture {
-            detailPresenter.present(id: String(product.id), name: product.name)
+            detailPresenter.present(id: product.id, name: product.name)
             onTap?()
         }
     }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -99,7 +99,7 @@ struct InventoryScreenView: View {
                                     isSearchFocused = false
                                 }
                                 .onTapGesture {
-                                    detailPresenter.present(id: product.name, name: product.name)
+                                    detailPresenter.present(id: product.id, name: product.name)
                                 }
                             }
                         }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -203,7 +203,7 @@ struct ProductDetailView: View {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailView(product: ProductIdentifier(id: "1", name: "Apple"))
+        ProductDetailView(product: ProductIdentifier(id: 1, name: "Apple"))
             .environmentObject(LocalizationManager())
     }
 }

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -37,14 +37,14 @@ struct SearchProductCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .onTapGesture {
-            detailPresenter.present(id: product.name, name: product.name)
+            detailPresenter.present(id: product.id, name: product.name)
             onTap()
         }
     }
 }
 
 #Preview {
-    SearchProductCardView(product: SearchProduct(name: "Ejemplo", image_url: "", stock_actual: 0, category: "", sensor_type: "manual"))
+    SearchProductCardView(product: SearchProduct(id: 0, name: "Ejemplo", image_url: "", stock_actual: 0, category: "", sensor_type: "manual"))
         .environmentObject(ThemeManager())
         .environmentObject(LocalizationManager())
         .environmentObject(ProductDetailPresenter())

--- a/NexStock1.0/ViewModels/ProductDetailPresenter.swift
+++ b/NexStock1.0/ViewModels/ProductDetailPresenter.swift
@@ -3,7 +3,8 @@ import SwiftUI
 
 /// Simple identifier used to present product details from any view.
 struct ProductIdentifier: Identifiable, Equatable {
-    let id: String
+    /// Backend identifier of the product
+    let id: Int
     let name: String
 }
 
@@ -12,7 +13,7 @@ final class ProductDetailPresenter: ObservableObject {
     @Published var selectedProduct: ProductIdentifier?
 
     /// Convenience method to present a product by id and name
-    func present(id: String, name: String) {
+    func present(id: Int, name: String) {
         selectedProduct = ProductIdentifier(id: id, name: name)
     }
 }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -6,7 +6,7 @@ class ProductDetailViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String?
 
-    func fetch(id: String) {
+    func fetch(id: Int) {
         guard !isLoading else { return }
         isLoading = true
 
@@ -19,16 +19,15 @@ class ProductDetailViewModel: ObservableObject {
                     self.detail = response.product
                     self.fetchMovements(id: id)
                     print("Product detail loaded", response)
-                case .failure(let error):
+                case .failure:
                     self.isLoading = false
-                    print("Failed to load detail", error)
-                    self.errorMessage = error.localizedDescription
+                    self.errorMessage = "Producto no disponible"
                 }
             }
         }
     }
 
-    private func fetchMovements(id: String) {
+    private func fetchMovements(id: Int) {
         ProductService.shared.fetchProductMovements(id: id) { [weak self] result in
             DispatchQueue.main.async {
                 guard let self = self else { return }


### PR DESCRIPTION
## Summary
- add product id to search results, product models, and inventory models
- keep product id as `Int` when presenting details
- use new `/detail` endpoint in `ProductService`
- handle missing product with a user-friendly message
- update all product card views to pass `id`

## Testing
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685b55b132148327980ddc5d5f52eb0d