### PR TITLE
Add global product detail modal

### DIFF
--- a/NexStock1.0/Models/DetailedProductModel.swift
+++ b/NexStock1.0/Models/DetailedProductModel.swift
@@ -51,6 +51,21 @@ struct DetailedProductModel: Identifiable, Codable {
     }
 }
 
+extension DetailedProductModel {
+    /// Creates a lightweight `ProductModel` instance used across the app
+    /// to present product details.
+    var asProductModel: ProductModel {
+        ProductModel(
+            id: String(id),
+            name: name,
+            image_url: image_url,
+            stock_actual: 0,
+            category: "",
+            sensor_type: input_method.rawValue
+        )
+    }
+}
+
 struct Category: Identifiable, Codable, Hashable {
     let id: Int
     let name: String

--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct ProductDetailResponse: Codable {
     let message: String?
-    let product: ProductDetailInfo
+    let product: ProductDetailInfo?
     /// Movements may be absent in the response so make it optional
     let movements: [ProductMovement]?
 }

--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -7,12 +7,30 @@ struct SearchResultResponse: Codable {
 }
 
 struct SearchProduct: Codable, Identifiable {
-    /// A stable identifier generated on initialization since the
-    /// backend search endpoint does not provide one.
+    /// Unique identifier for the list diffing
     let id: UUID = UUID()
+    /// Identifier provided by the backend used for further requests
+    let serverID: String
     let name: String
     let image_url: String
     let stock_actual: Int
     let category: String
     let sensor_type: String
+
+    enum CodingKeys: String, CodingKey {
+        case serverID = "id"
+        case name, image_url, stock_actual, category, sensor_type
+    }
+
+    /// Helper to transform the search result into a common `ProductModel`
+    var asProductModel: ProductModel {
+        ProductModel(
+            id: serverID,
+            name: name,
+            image_url: image_url,
+            stock_actual: stock_actual,
+            category: category,
+            sensor_type: sensor_type
+        )
+    }
 }

--- a/NexStock1.0/NexStock1_0App.swift
+++ b/NexStock1.0/NexStock1_0App.swift
@@ -12,6 +12,7 @@ struct NexStock1_0App: App {
     @AppStorage("selectedAppearance") private var selectedAppearance = "system"
     @StateObject private var localizationManager = LocalizationManager.shared
     @StateObject private var authService = AuthService.shared
+    @StateObject private var detailPresenter = ProductDetailPresenter.shared
 
     init() {
         applyAppearance()
@@ -23,6 +24,7 @@ struct NexStock1_0App: App {
                 .environmentObject(localizationManager)
                 .environmentObject(authService)
                 .environmentObject(ThemeManager.shared)
+                .environmentObject(detailPresenter)
         }
     }
 

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -87,7 +87,9 @@ class ProductService {
     }
 
     func fetchProductDetail(id: String, completion: @escaping (Result<ProductDetailResponse, Error>) -> Void) {
-        guard let url = URL(string: baseURL + "/" + id) else { return }
+        var components = URLComponents(string: baseURL + "/detail")
+        components?.queryItems = [URLQueryItem(name: "id", value: id)]
+        guard let url = components?.url else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data {
@@ -108,7 +110,9 @@ class ProductService {
 
     /// Fetch only the movement history for a product
     func fetchProductMovements(id: String, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
-        guard let url = URL(string: baseURL + "/" + id + "/movements") else { return }
+        var components = URLComponents(string: baseURL + "/movements")
+        components?.queryItems = [URLQueryItem(name: "id", value: id)]
+        guard let url = components?.url else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, error in
             if let data = data {

--- a/NexStock1.0/Utils/ProductDetailPresenter.swift
+++ b/NexStock1.0/Utils/ProductDetailPresenter.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+class ProductDetailPresenter: ObservableObject {
+    static let shared = ProductDetailPresenter()
+    @Published var selectedProduct: ProductModel?
+
+    func present(product: ProductModel) {
+        selectedProduct = product
+    }
+}

--- a/NexStock1.0/View/AppView.swift
+++ b/NexStock1.0/View/AppView.swift
@@ -12,6 +12,7 @@ struct AppView: View {
     @State private var showMenu = false // ✅ AGREGA ESTA LÍNEA
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -43,6 +44,10 @@ struct AppView: View {
                         AlertView(path: $path)
                     }
                 }
+        }
+        .sheet(item: $detailPresenter.selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
         }
     }
 }

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -12,6 +12,7 @@ struct InventoryCardView: View {
     var onTap: (() -> Void)? = nil
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         VStack(spacing: 8) {
@@ -45,6 +46,7 @@ struct InventoryCardView: View {
         .shadow(radius: 2)
         .onTapGesture {
             onTap?()
+            detailPresenter.present(product: product.asProductModel)
         }
     }
 }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
-    var onProductTap: (ProductModel) -> Void = { _ in }
 
     var body: some View {
         ScrollView {
@@ -16,12 +15,10 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        ProductCard(product: product) {
-                                            onProductTap(product)
-                                        }
-                                        .onAppear {
-                                            viewModel.loadMoreIfNeeded(currentItem: product, category: category)
-                                        }
+                                        ProductCard(product: product)
+                                            .onAppear {
+                                                viewModel.loadMoreIfNeeded(currentItem: product, category: category)
+                                            }
                                     }
                                 }
                                 .padding(.horizontal)
@@ -40,6 +37,7 @@ struct InventoryGroupView: View {
 struct ProductCard: View {
     let product: ProductModel
     var onTap: () -> Void = {}
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -62,7 +60,10 @@ struct ProductCard: View {
         .padding()
         .background(Color.secondaryColor)
         .cornerRadius(12)
-        .onTapGesture { onTap() }
+        .onTapGesture {
+            onTap()
+            detailPresenter.present(product: product)
+        }
     }
 }
 
@@ -71,5 +72,6 @@ struct InventoryGroupView_Previews: PreviewProvider {
         InventoryGroupView()
             .environmentObject(ThemeManager())
             .environmentObject(LocalizationManager())
+            .environmentObject(ProductDetailPresenter())
     }
 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -20,7 +20,6 @@ struct InventoryScreenView: View {
     @StateObject private var searchVM = ProductSearchViewModel()
     @FocusState private var isSearchFocused: Bool
     @State private var showAddProductSheet = false
-    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -42,10 +41,6 @@ struct InventoryScreenView: View {
                 showAddProductSheet = false
             }
             .environmentObject(authService)
-        }
-        .sheet(item: $selectedProduct) { product in
-            ProductDetailView(product: product)
-                .environmentObject(localization)
         }
         .navigationBarBackButtonHidden(true)
         .onChange(of: showAddProductSheet) { isPresented in
@@ -86,9 +81,7 @@ struct InventoryScreenView: View {
     private var productList: some View {
         Group {
             if searchVM.query.isEmpty {
-                InventoryGroupView { product in
-                    selectedProduct = product
-                }
+                InventoryGroupView()
             } else {
                 ScrollView {
                     if searchVM.isLoading {

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SearchProductCardView: View {
     let product: SearchProduct
     var onTap: () -> Void = {}
+    @EnvironmentObject var detailPresenter: ProductDetailPresenter
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -35,12 +36,25 @@ struct SearchProductCardView: View {
         .padding()
         .background(Color.secondaryColor)
         .cornerRadius(12)
-        .onTapGesture { onTap() }
+        .onTapGesture {
+            onTap()
+            detailPresenter.present(product: product.asProductModel)
+        }
     }
 }
 
 #Preview {
-    SearchProductCardView(product: SearchProduct(name: "Ejemplo", image_url: "", stock_actual: 0, category: "", sensor_type: "manual"))
+    SearchProductCardView(
+        product: SearchProduct(
+            serverID: "1",
+            name: "Ejemplo",
+            image_url: "",
+            stock_actual: 0,
+            category: "",
+            sensor_type: "manual"
+        )
+    )
         .environmentObject(ThemeManager())
         .environmentObject(LocalizationManager())
+        .environmentObject(ProductDetailPresenter())
 }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -16,9 +16,14 @@ class ProductDetailViewModel: ObservableObject {
 
                 switch result {
                 case .success(let response):
-                    self.detail = response.product
-                    self.fetchMovements(id: id)
-                    print("Product detail loaded", response)
+                    if let product = response.product {
+                        self.detail = product
+                        self.fetchMovements(id: id)
+                        print("Product detail loaded", response)
+                    } else {
+                        self.isLoading = false
+                        self.errorMessage = response.message ?? "Producto no disponible"
+                    }
                 case .failure(let error):
                     self.isLoading = false
                     print("Failed to load detail", error)


### PR DESCRIPTION
## Summary
- introduce `ProductDetailPresenter` to handle product detail sheet globally
- update search result model to include server ID and conversion helper
- convert detailed products to simple product models
- update product service endpoints to use query-based ID
- show product detail from any product card via the presenter
- propagate presenter through the app scene

## Testing
- `swift --version`
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b586496d48327a221dcc7855858a7