### PR TITLE
Enable product detail modal from more views

### DIFF
--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeInventoryCardView: View {
     let product: InventoryProduct
+    var onTap: () -> Void = {}
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -25,5 +26,6 @@ struct HomeInventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture { onTap() }
     }
 }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
+    var onProductTap: (InventoryProduct) -> Void = { _ in }
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -15,7 +16,7 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        HomeInventoryCardView(product: product)
+                        HomeInventoryCardView(product: product, onTap: { onProductTap(product) })
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @Binding var path: NavigationPath
     @State private var showMenu = false
     @StateObject private var summaryVM = HomeSummaryViewModel()
+    @State private var selectedProduct: ProductModel? = nil
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
 
@@ -40,19 +41,29 @@ struct HomeView: View {
 
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
-                                HomeSummarySectionView(title: "expiring".localized, products: items)
+                                HomeSummarySectionView(title: "expiring".localized, products: items) { product in
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url ?? "", stock_actual: product.stock_actual ?? 0, category: "", sensor_type: product.sensor_type ?? "")
+                                }
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "out_of_stock".localized, products: items)
+                                HomeSummarySectionView(title: "out_of_stock".localized, products: items) { product in
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url ?? "", stock_actual: product.stock_actual ?? 0, category: "", sensor_type: product.sensor_type ?? "")
+                                }
                             }
                             if let items = summary.low_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "below_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "below_minimum".localized, products: items) { product in
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url ?? "", stock_actual: product.stock_actual ?? 0, category: "", sensor_type: product.sensor_type ?? "")
+                                }
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
-                                HomeSummarySectionView(title: "near_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "near_minimum".localized, products: items) { product in
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url ?? "", stock_actual: product.stock_actual ?? 0, category: "", sensor_type: product.sensor_type ?? "")
+                                }
                             }
                             if let items = summary.overstock, !items.isEmpty {
-                                HomeSummarySectionView(title: "overstock".localized, products: items)
+                                HomeSummarySectionView(title: "overstock".localized, products: items) { product in
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url ?? "", stock_actual: product.stock_actual ?? 0, category: "", sensor_type: product.sensor_type ?? "")
+                                }
                             }
                         }
                     }
@@ -68,6 +79,10 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
         .task { summaryVM.fetchSummary() }
     }
 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -102,6 +102,7 @@ struct InventoryScreenView: View {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
                                 SearchProductCardView(product: product) {
+                                    selectedProduct = ProductModel(id: product.name, name: product.name, image_url: product.image_url, stock_actual: product.stock_actual, category: product.category, sensor_type: product.sensor_type)
                                     isSearchFocused = false
                                 }
                             }


### PR DESCRIPTION
## Summary
- make `HomeInventoryCardView` tappable
- expose tap callback in `HomeSummarySectionView`
- show product detail modal when tapping products from Home
- trigger the same modal from search results

## Testing
- `swift --version`
- `swiftc -emit-library -o /tmp/tmp.o NexStock1.0/View/HomeInventoryCardView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685b5bc9941483279019624f1f8ff250