### PR TITLE
Enable product detail modal on home and search

### DIFF
--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeInventoryCardView: View {
     let product: InventoryProduct
+    var onTap: () -> Void = {}
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -25,5 +26,6 @@ struct HomeInventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture { onTap() }
     }
 }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
+    var onProductTap: (InventoryProduct) -> Void = { _ in }
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -15,7 +16,9 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        HomeInventoryCardView(product: product)
+                        HomeInventoryCardView(product: product) {
+                            onProductTap(product)
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @Binding var path: NavigationPath
     @State private var showMenu = false
     @StateObject private var summaryVM = HomeSummaryViewModel()
+    @State private var selectedProduct: ProductModel? = nil
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
 
@@ -40,19 +41,29 @@ struct HomeView: View {
 
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
-                                HomeSummarySectionView(title: "expiring".localized, products: items)
+                                HomeSummarySectionView(title: "expiring".localized, products: items) { prod in
+                                    selectedProduct = convert(prod)
+                                }
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "out_of_stock".localized, products: items)
+                                HomeSummarySectionView(title: "out_of_stock".localized, products: items) { prod in
+                                    selectedProduct = convert(prod)
+                                }
                             }
                             if let items = summary.low_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "below_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "below_minimum".localized, products: items) { prod in
+                                    selectedProduct = convert(prod)
+                                }
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
-                                HomeSummarySectionView(title: "near_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "near_minimum".localized, products: items) { prod in
+                                    selectedProduct = convert(prod)
+                                }
                             }
                             if let items = summary.overstock, !items.isEmpty {
-                                HomeSummarySectionView(title: "overstock".localized, products: items)
+                                HomeSummarySectionView(title: "overstock".localized, products: items) { prod in
+                                    selectedProduct = convert(prod)
+                                }
                             }
                         }
                     }
@@ -67,8 +78,25 @@ struct HomeView: View {
             }
         }
         .animation(.easeInOut, value: showMenu)
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
         .navigationBarBackButtonHidden(true)
         .task { summaryVM.fetchSummary() }
+    }
+}
+
+private extension HomeView {
+    func convert(_ item: InventoryProduct) -> ProductModel {
+        ProductModel(
+            id: UUID().uuidString,
+            name: item.name,
+            image_url: item.image_url ?? "",
+            stock_actual: item.stock_actual ?? 0,
+            category: "",
+            sensor_type: item.sensor_type ?? ""
+        )
     }
 }
 

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -102,6 +102,14 @@ struct InventoryScreenView: View {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
                                 SearchProductCardView(product: product) {
+                                    selectedProduct = ProductModel(
+                                        id: product.id.uuidString,
+                                        name: product.name,
+                                        image_url: product.image_url,
+                                        stock_actual: product.stock_actual,
+                                        category: product.category,
+                                        sensor_type: product.sensor_type
+                                    )
                                     isSearchFocused = false
                                 }
                             }


### PR DESCRIPTION
## Summary
- tap product cards on the home screen to show the detail modal
- tap search results to show the detail modal
- expose tap handlers on `HomeInventoryCardView` and `HomeSummarySectionView`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b5eacbeec83279c8f727b2d3d90a0