### PR TITLE
Enable product detail modal across views

### DIFF
--- a/NexStock1.0/Models/ProductModel+Extensions.swift
+++ b/NexStock1.0/Models/ProductModel+Extensions.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension ProductModel {
+    init(from search: SearchProduct) {
+        self.id = search.id.uuidString
+        self.name = search.name
+        self.image_url = search.image_url
+        self.stock_actual = search.stock_actual
+        self.category = search.category
+        self.sensor_type = search.sensor_type
+    }
+
+    init(from inventory: InventoryProduct) {
+        self.id = inventory.name
+        self.name = inventory.name
+        self.image_url = inventory.image_url ?? ""
+        self.stock_actual = inventory.stock_actual ?? 0
+        self.category = ""
+        self.sensor_type = inventory.sensor_type ?? ""
+    }
+}

--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeInventoryCardView: View {
     let product: InventoryProduct
+    var onTap: (() -> Void)? = nil
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -25,5 +26,8 @@ struct HomeInventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture {
+            onTap?()
+        }
     }
 }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
+    var onProductTap: (ProductModel) -> Void = { _ in }
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -15,7 +16,9 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        HomeInventoryCardView(product: product)
+                        HomeInventoryCardView(product: product) {
+                            onProductTap(ProductModel(from: product))
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -11,6 +11,7 @@ struct HomeView: View {
     @Binding var path: NavigationPath
     @State private var showMenu = false
     @StateObject private var summaryVM = HomeSummaryViewModel()
+    @State private var selectedProduct: ProductModel? = nil
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
 
@@ -40,19 +41,29 @@ struct HomeView: View {
 
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
-                                HomeSummarySectionView(title: "expiring".localized, products: items)
+                                HomeSummarySectionView(title: "expiring".localized, products: items) { product in
+                                    selectedProduct = product
+                                }
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "out_of_stock".localized, products: items)
+                                HomeSummarySectionView(title: "out_of_stock".localized, products: items) { product in
+                                    selectedProduct = product
+                                }
                             }
                             if let items = summary.low_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "below_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "below_minimum".localized, products: items) { product in
+                                    selectedProduct = product
+                                }
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
-                                HomeSummarySectionView(title: "near_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "near_minimum".localized, products: items) { product in
+                                    selectedProduct = product
+                                }
                             }
                             if let items = summary.overstock, !items.isEmpty {
-                                HomeSummarySectionView(title: "overstock".localized, products: items)
+                                HomeSummarySectionView(title: "overstock".localized, products: items) { product in
+                                    selectedProduct = product
+                                }
                             }
                         }
                     }
@@ -67,6 +78,10 @@ struct HomeView: View {
             }
         }
         .animation(.easeInOut, value: showMenu)
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
         .navigationBarBackButtonHidden(true)
         .task { summaryVM.fetchSummary() }
     }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -103,6 +103,7 @@ struct InventoryScreenView: View {
                             ForEach(searchVM.results) { product in
                                 SearchProductCardView(product: product) {
                                     isSearchFocused = false
+                                    selectedProduct = ProductModel(from: product)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- add converters from inventory and search models to `ProductModel`
- allow `HomeInventoryCardView` to react on taps
- expose tap actions in home summary sections
- open product detail from home summary sections
- allow selecting products from search results

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b60a1d7108327b11bfd17fc02f168