### PR TITLE
Enable product detail modal on Home and Search

### DIFF
--- a/NexStock1.0/Models/ProductModel+Conversion.swift
+++ b/NexStock1.0/Models/ProductModel+Conversion.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension ProductModel {
+    init(from search: SearchProduct) {
+        self.init(
+            id: "0",
+            name: search.name,
+            image_url: search.image_url,
+            stock_actual: search.stock_actual,
+            category: search.category,
+            sensor_type: search.sensor_type
+        )
+    }
+
+    init(from inventory: InventoryProduct) {
+        self.init(
+            id: "0",
+            name: inventory.name,
+            image_url: inventory.image_url ?? "",
+            stock_actual: inventory.stock_actual ?? 0,
+            category: "",
+            sensor_type: inventory.sensor_type ?? ""
+        )
+    }
+}

--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeInventoryCardView: View {
     let product: InventoryProduct
+    var onTap: () -> Void = {}
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -25,5 +26,6 @@ struct HomeInventoryCardView: View {
         .background(Color.secondaryColor)
         .cornerRadius(12)
         .shadow(radius: 2)
+        .onTapGesture { onTap() }
     }
 }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
+    var onProductTap: (InventoryProduct) -> Void = { _ in }
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -15,7 +16,9 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        HomeInventoryCardView(product: product)
+                        HomeInventoryCardView(product: product) {
+                            onProductTap(product)
+                        }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
     @StateObject private var summaryVM = HomeSummaryViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
+    @State private var selectedProduct: ProductModel? = nil
 
 
     var body: some View {
@@ -40,19 +41,29 @@ struct HomeView: View {
 
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
-                                HomeSummarySectionView(title: "expiring".localized, products: items)
+                                HomeSummarySectionView(title: "expiring".localized, products: items) { product in
+                                    selectedProduct = ProductModel(from: product)
+                                }
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "out_of_stock".localized, products: items)
+                                HomeSummarySectionView(title: "out_of_stock".localized, products: items) { product in
+                                    selectedProduct = ProductModel(from: product)
+                                }
                             }
                             if let items = summary.low_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "below_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "below_minimum".localized, products: items) { product in
+                                    selectedProduct = ProductModel(from: product)
+                                }
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
-                                HomeSummarySectionView(title: "near_minimum".localized, products: items)
+                                HomeSummarySectionView(title: "near_minimum".localized, products: items) { product in
+                                    selectedProduct = ProductModel(from: product)
+                                }
                             }
                             if let items = summary.overstock, !items.isEmpty {
-                                HomeSummarySectionView(title: "overstock".localized, products: items)
+                                HomeSummarySectionView(title: "overstock".localized, products: items) { product in
+                                    selectedProduct = ProductModel(from: product)
+                                }
                             }
                         }
                     }
@@ -68,6 +79,10 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
         .task { summaryVM.fetchSummary() }
     }
 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -103,6 +103,7 @@ struct InventoryScreenView: View {
                             ForEach(searchVM.results) { product in
                                 SearchProductCardView(product: product) {
                                     isSearchFocused = false
+                                    selectedProduct = ProductModel(from: product)
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- convert search/home models into `ProductModel` for sheet display
- allow tapping home inventory cards
- bubble tap action through summary section
- show product detail sheet from Home
- handle taps on search results

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b62ea06bc83279d2c3f8617a2afdb