### PR TITLE
Ensure product lists use InventoryCardView with sheet navigation

### DIFF
--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -16,9 +16,8 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
-                            onProductTap(product)
-                        }
+                        InventoryCardView(product: product)
+                            .onTapGesture { onProductTap(product) }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -16,9 +16,10 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        InventoryCardView(product: product) {
-                                            onProductTap(product)
-                                        }
+                                        InventoryCardView(product: product)
+                                            .onTapGesture {
+                                                onProductTap(product)
+                                            }
                                         .onAppear {
                                             viewModel.loadMoreIfNeeded(currentItem: product, category: category)
                                         }

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -27,9 +27,10 @@ struct InventoryHomeSectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
-                            selectedProduct = ProductModel(from: product)
-                        }
+                        InventoryCardView(product: product)
+                            .onTapGesture {
+                                selectedProduct = ProductModel(from: product)
+                            }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -101,10 +101,11 @@ struct InventoryScreenView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                InventoryCardView(product: product) {
-                                    isSearchFocused = false
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                InventoryCardView(product: product)
+                                    .onTapGesture {
+                                        isSearchFocused = false
+                                        selectedProduct = ProductModel(from: product)
+                                    }
                             }
                         }
                         .padding()


### PR DESCRIPTION
## Summary
- standardize product card tap handling
- use InventoryCardView directly in product lists
- open ProductDetailView via `.sheet` consistently

## Testing
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c5e6607c48327ae59d313f994840d