### PR TITLE
Implement consistent product detail modals

### DIFF
--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
-    var onProductTap: (InventoryProduct) -> Void = { _ in }
+    @State private var selectedProduct: ProductModel? = nil
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -16,13 +16,18 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
-                            onProductTap(product)
-                        }
+                        InventoryCardView(product: product)
+                            .onTapGesture {
+                                selectedProduct = ProductModel(from: product)
+                            }
                     }
                 }
                 .padding(.horizontal)
             }
+        }
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
         }
     }
 }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -13,7 +13,6 @@ struct HomeView: View {
     @StateObject private var summaryVM = HomeSummaryViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
-    @State private var selectedProduct: ProductModel? = nil
 
 
     var body: some View {
@@ -41,29 +40,19 @@ struct HomeView: View {
 
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
-                                HomeSummarySectionView(title: "expiring".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                HomeSummarySectionView(title: "expiring".localized, products: items)
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "out_of_stock".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                HomeSummarySectionView(title: "out_of_stock".localized, products: items)
                             }
                             if let items = summary.low_stock, !items.isEmpty {
-                                HomeSummarySectionView(title: "below_minimum".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                HomeSummarySectionView(title: "below_minimum".localized, products: items)
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
-                                HomeSummarySectionView(title: "near_minimum".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                HomeSummarySectionView(title: "near_minimum".localized, products: items)
                             }
                             if let items = summary.overstock, !items.isEmpty {
-                                HomeSummarySectionView(title: "overstock".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                HomeSummarySectionView(title: "overstock".localized, products: items)
                             }
                         }
                     }
@@ -79,10 +68,6 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
-        .sheet(item: $selectedProduct) { product in
-            ProductDetailView(product: product)
-                .environmentObject(localization)
-        }
         .task { summaryVM.fetchSummary() }
     }
 }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
-    var onProductTap: (ProductModel) -> Void = { _ in }
+    @State private var selectedProduct: ProductModel? = nil
+    @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         ScrollView {
@@ -16,12 +17,13 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        InventoryCardView(product: product) {
-                                            onProductTap(product)
-                                        }
-                                        .onAppear {
-                                            viewModel.loadMoreIfNeeded(currentItem: product, category: category)
-                                        }
+                                        InventoryCardView(product: product)
+                                            .onTapGesture {
+                                                selectedProduct = product
+                                            }
+                                            .onAppear {
+                                                viewModel.loadMoreIfNeeded(currentItem: product, category: category)
+                                            }
                                     }
                                 }
                                 .padding(.horizontal)
@@ -33,6 +35,10 @@ struct InventoryGroupView: View {
         }
         .onAppear {
             viewModel.fetchInitial()
+        }
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
         }
     }
 }

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -27,9 +27,10 @@ struct InventoryHomeSectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
-                            selectedProduct = ProductModel(from: product)
-                        }
+                        InventoryCardView(product: product)
+                            .onTapGesture {
+                                selectedProduct = ProductModel(from: product)
+                            }
                     }
                 }
                 .padding(.horizontal)

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -86,9 +86,7 @@ struct InventoryScreenView: View {
     private var productList: some View {
         Group {
             if searchVM.query.isEmpty {
-                InventoryGroupView { product in
-                    selectedProduct = product
-                }
+                InventoryGroupView()
             } else {
                 ScrollView {
                     if searchVM.isLoading {
@@ -101,10 +99,11 @@ struct InventoryScreenView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                InventoryCardView(product: product) {
-                                    isSearchFocused = false
-                                    selectedProduct = ProductModel(from: product)
-                                }
+                                InventoryCardView(product: product)
+                                    .onTapGesture {
+                                        isSearchFocused = false
+                                        selectedProduct = ProductModel(from: product)
+                                    }
                             }
                         }
                         .padding()


### PR DESCRIPTION
## Summary
- standardize product taps to open `ProductDetailView`
- update search, inventory, and home sections to use `InventoryCardView` with `.onTapGesture`
- remove unused callbacks and old sheet handling in `HomeView`

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c609ecbdc8327867a975e1a78a54c