### PR TITLE
Unify product card layout across screens

### DIFF
--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -7,20 +7,33 @@ struct HomeInventoryCardView: View {
     @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
-        VStack(spacing: 8) {
-            if let urlString = product.image_url, let url = URL(string: urlString) {
+        VStack(alignment: .leading, spacing: 4) {
+            if let urlString = product.image_url,
+               let url = URL(string: urlString) {
                 AsyncImage(url: url) { image in
                     image.resizable()
                 } placeholder: {
                     ProgressView()
                 }
-                .frame(width: 80, height: 80)
-                .cornerRadius(10)
+                .frame(width: 120, height: 120)
+                .cornerRadius(8)
             }
 
             Text(product.name)
                 .font(.headline)
                 .foregroundColor(.tertiaryColor)
+
+            if let stock = product.stock_actual {
+                Text("Stock: \(stock)")
+                    .font(.caption)
+                    .foregroundColor(.tertiaryColor)
+            }
+
+            if let sensor = product.sensor_type {
+                Text("Sensor: \(sensor.localized)")
+                    .font(.caption)
+                    .foregroundColor(.tertiaryColor)
+            }
         }
         .padding()
         .background(Color.secondaryColor)

--- a/NexStock1.0/View/SearchProductCardView.swift
+++ b/NexStock1.0/View/SearchProductCardView.swift
@@ -20,10 +20,6 @@ struct SearchProductCardView: View {
                 .font(.headline)
                 .foregroundColor(.tertiaryColor)
 
-            Text(product.category.localized)
-                .font(.subheadline)
-                .foregroundColor(.tertiaryColor)
-
             Text("Stock: \(product.stock_actual)")
                 .font(.caption)
                 .foregroundColor(.tertiaryColor)


### PR DESCRIPTION
## Summary
- make Home inventory cards display the same info as inventory cards
- update search results cards to match inventory card design

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c6c0839f48327aebd970c62d926a0