### PR TITLE
Implement monitoring API integration

### DIFF
--- a/NexStock1.0/Models/MonitoringModels.swift
+++ b/NexStock1.0/Models/MonitoringModels.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct MonitoringNotification: Identifiable, Codable {
+    let id = UUID()
+    let type: String
+    let message: String
+    let timestamp: String
+}
+
+struct MonitoringHomeResponse: Codable {
+    let temperature: Double
+    let humidity: Double
+    let unread_notifications: [MonitoringNotification]
+}
+
+struct MonitoringGraphResponse: Codable {
+    let current: Double
+    let average: Double
+    let min: Double
+    let max: Double
+    let points: [MonitoringPoint]
+}

--- a/NexStock1.0/Models/MonitoringPoint.swift
+++ b/NexStock1.0/Models/MonitoringPoint.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MonitoringPoint: Identifiable {
+struct MonitoringPoint: Identifiable, Codable {
     let id = UUID()
     let time: Date
     let value: Double

--- a/NexStock1.0/Services/MonitoringService.swift
+++ b/NexStock1.0/Services/MonitoringService.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+class MonitoringService {
+    static let shared = MonitoringService()
+    private let baseURL = NetworkConfig.monitoringBaseURL + "/monitoring"
+
+    func fetchHome(completion: @escaping (Result<MonitoringHomeResponse, Error>) -> Void) {
+        guard let url = URL(string: baseURL + "/home") else { return }
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let data = data {
+                do {
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .iso8601
+                    let decoded = try decoder.decode(MonitoringHomeResponse.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    completion(.failure(error))
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+
+    func fetchTemperatureGraph(filter: String, completion: @escaping (Result<MonitoringGraphResponse, Error>) -> Void) {
+        requestGraph(path: "/temperature-graph", filter: filter, completion: completion)
+    }
+
+    func fetchHumidityGraph(filter: String, completion: @escaping (Result<MonitoringGraphResponse, Error>) -> Void) {
+        requestGraph(path: "/humidity-graph", filter: filter, completion: completion)
+    }
+
+    private func requestGraph(path: String, filter: String, completion: @escaping (Result<MonitoringGraphResponse, Error>) -> Void) {
+        guard var components = URLComponents(string: baseURL + path) else { return }
+        components.queryItems = [URLQueryItem(name: "filter", value: filter)]
+        guard let url = components.url else { return }
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let data = data {
+                do {
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .iso8601
+                    let decoded = try decoder.decode(MonitoringGraphResponse.self, from: data)
+                    completion(.success(decoded))
+                } catch {
+                    if let http = response as? HTTPURLResponse, http.statusCode == 400 {
+                        completion(.failure(NSError(domain: "MonitoringService", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid filter"])))
+                    } else {
+                        completion(.failure(error))
+                    }
+                }
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}

--- a/NexStock1.0/Utils/NavigationRoutes.swift
+++ b/NexStock1.0/Utils/NavigationRoutes.swift
@@ -15,5 +15,8 @@ enum AppRoute: Hashable {
     case product
     case temperature
     case humidity
+    case monitoringHome
+    case temperatureGraph
+    case humidityGraph
     case alerts
 }

--- a/NexStock1.0/Utils/NetworkConstants.swift
+++ b/NexStock1.0/Utils/NetworkConstants.swift
@@ -3,4 +3,5 @@ import Foundation
 struct NetworkConfig {
     static let inventoryBaseURL = "https://inventory.nexusutd.online"
     static let authBaseURL = "https://auth.nexusutd.online"
+    static let monitoringBaseURL = "https://monitoring.nexusutd.online"
 }

--- a/NexStock1.0/View/AppView.swift
+++ b/NexStock1.0/View/AppView.swift
@@ -39,6 +39,12 @@ struct AppView: View {
                         TemperatureView(path: $path)
                     case .humidity:
                         HumidityView(path: $path)
+                    case .monitoringHome:
+                        MonitoringHomeView(path: $path)
+                    case .temperatureGraph:
+                        TemperatureGraphView(path: $path)
+                    case .humidityGraph:
+                        HumidityGraphView(path: $path)
                     case .alerts:
                         AlertView(path: $path)
                     }

--- a/NexStock1.0/View/HumidityGraphView.swift
+++ b/NexStock1.0/View/HumidityGraphView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct HumidityGraphView: View {
+    @Binding var path: NavigationPath
+    @StateObject private var viewModel = HumidityGraphViewModel()
+    @State private var showMenu = false
+    @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.backColor.ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                HeaderView(showMenu: $showMenu, path: $path)
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            ForEach(viewModel.filters, id: \..self) { filter in
+                                Button(action: { viewModel.selectedFilter = filter }) {
+                                    Text(filter)
+                                        .font(.subheadline)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 6)
+                                        .background(viewModel.selectedFilter == filter ? Color.secondaryColor : Color.secondaryColor.opacity(0.3))
+                                        .cornerRadius(8)
+                                        .foregroundColor(.tertiaryColor)
+                                }
+                            }
+                        }
+
+                        SectionContainer(title: "") {
+                            LineChartView(
+                                data: viewModel.chartValues,
+                                labels: viewModel.xAxisLabels
+                            )
+                        }
+
+                        SectionContainer(title: "") {
+                            HStack {
+                                infoBox(title: "current_humidity".localized, value: String(format: "%.1f%%", viewModel.current))
+                                infoBox(title: "average".localized, value: String(format: "%.1f%%", viewModel.average))
+                                infoBox(title: "minimum".localized, value: String(format: "%.1f%%", viewModel.min))
+                                infoBox(title: "maximum".localized, value: String(format: "%.1f%%", viewModel.max))
+                            }
+                        }
+                    }
+                    .padding()
+                }
+            }
+
+            if showMenu {
+                SideMenuView(isOpen: $showMenu, path: $path)
+                    .transition(.move(edge: .leading))
+                    .zIndex(1)
+            }
+        }
+        .animation(.easeInOut, value: showMenu)
+        .navigationBarBackButtonHidden(true)
+    }
+
+    private func infoBox(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundColor(.tertiaryColor)
+            Text(value)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(Color.secondaryColor)
+        .cornerRadius(10)
+    }
+}

--- a/NexStock1.0/View/MonitoringHomeView.swift
+++ b/NexStock1.0/View/MonitoringHomeView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct MonitoringHomeView: View {
+    @Binding var path: NavigationPath
+    @StateObject private var viewModel = MonitoringHomeViewModel()
+    @State private var showMenu = false
+    @State private var selectedNotification: MonitoringNotification?
+    @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.backColor.ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                HeaderView(showMenu: $showMenu, path: $path)
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 20) {
+                            MonitoringInfoCard(title: "temperature".localized, value: String(format: "%.1f°C", viewModel.temperature))
+                            MonitoringInfoCard(title: "humidity".localized, value: String(format: "%.1f%%", viewModel.humidity))
+                        }
+
+                        SectionContainer(title: "Notifications") {
+                            ForEach(viewModel.notifications) { notification in
+                                MonitoringNotificationCard(notification: notification)
+                                    .onTapGesture { selectedNotification = notification }
+                            }
+                        }
+                    }
+                    .padding()
+                }
+            }
+
+            if showMenu {
+                SideMenuView(isOpen: $showMenu, path: $path)
+                    .transition(.move(edge: .leading))
+                    .zIndex(1)
+            }
+        }
+        .animation(.easeInOut, value: showMenu)
+        .navigationBarBackButtonHidden(true)
+        .sheet(item: $selectedNotification) { notif in
+            NotificationDetailSheet(notification: notif)
+        }
+        .onAppear { viewModel.fetch() }
+    }
+}
+
+struct MonitoringInfoCard: View {
+    let title: String
+    let value: String
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+            Text(value)
+                .font(.subheadline)
+                .foregroundColor(.tertiaryColor.opacity(0.7))
+        }
+        .frame(width: 120, height: 120)
+        .background(Color.secondaryColor)
+        .cornerRadius(12)
+        .shadow(radius: 2)
+    }
+}
+
+struct MonitoringNotificationCard: View {
+    let notification: MonitoringNotification
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(notification.type)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+            Text(notification.message)
+                .font(.caption)
+                .foregroundColor(.tertiaryColor.opacity(0.7))
+            Text(notification.timestamp)
+                .font(.caption2)
+                .foregroundColor(.tertiaryColor.opacity(0.6))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color.secondaryColor)
+        .cornerRadius(12)
+        .shadow(radius: 1)
+    }
+}
+
+struct NotificationDetailSheet: View {
+    let notification: MonitoringNotification
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(notification.type)
+                .font(.title3)
+            Text(notification.message)
+                .font(.body)
+            Text(notification.timestamp)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .padding()
+    }
+}

--- a/NexStock1.0/View/SideMenuView.swift
+++ b/NexStock1.0/View/SideMenuView.swift
@@ -123,13 +123,19 @@ struct SideMenuView: View {
                     if activeMenu == "monitoreo" {
                         VStack(alignment: .leading, spacing: 6) {
                             Button {
-                                path.append(AppRoute.temperature)
+                                path.append(AppRoute.monitoringHome)
+                            } label: {
+                                Text("home".localized)
+                            }
+
+                            Button {
+                                path.append(AppRoute.temperatureGraph)
                             } label: {
                                 Text("temperature".localized)
                             }
 
                             Button {
-                                path.append(AppRoute.humidity)
+                                path.append(AppRoute.humidityGraph)
                             } label: {
                                 Text("humidity".localized)
                             }

--- a/NexStock1.0/View/TemperatureGraphView.swift
+++ b/NexStock1.0/View/TemperatureGraphView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct TemperatureGraphView: View {
+    @Binding var path: NavigationPath
+    @StateObject private var viewModel = TemperatureGraphViewModel()
+    @State private var showMenu = false
+    @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.backColor.ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                HeaderView(showMenu: $showMenu, path: $path)
+
+                ScrollView {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            ForEach(viewModel.filters, id: \..self) { filter in
+                                Button(action: { viewModel.selectedFilter = filter }) {
+                                    Text(filter)
+                                        .font(.subheadline)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 6)
+                                        .background(viewModel.selectedFilter == filter ? Color.secondaryColor : Color.secondaryColor.opacity(0.3))
+                                        .cornerRadius(8)
+                                        .foregroundColor(.tertiaryColor)
+                                }
+                            }
+                        }
+
+                        SectionContainer(title: "") {
+                            LineChartView(
+                                data: viewModel.chartValues,
+                                labels: viewModel.xAxisLabels
+                            )
+                        }
+
+                        SectionContainer(title: "") {
+                            HStack {
+                                infoBox(title: "current_temperature".localized, value: String(format: "%.1f°C", viewModel.current))
+                                infoBox(title: "average".localized, value: String(format: "%.1f°C", viewModel.average))
+                                infoBox(title: "minimum".localized, value: String(format: "%.1f°C", viewModel.min))
+                                infoBox(title: "maximum".localized, value: String(format: "%.1f°C", viewModel.max))
+                            }
+                        }
+                    }
+                    .padding()
+                }
+            }
+
+            if showMenu {
+                SideMenuView(isOpen: $showMenu, path: $path)
+                    .transition(.move(edge: .leading))
+                    .zIndex(1)
+            }
+        }
+        .animation(.easeInOut, value: showMenu)
+        .navigationBarBackButtonHidden(true)
+    }
+
+    private func infoBox(title: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(title)
+                .font(.caption2)
+                .foregroundColor(.tertiaryColor)
+            Text(value)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(Color.secondaryColor)
+        .cornerRadius(10)
+    }
+}

--- a/NexStock1.0/ViewModels/HumidityGraphViewModel.swift
+++ b/NexStock1.0/ViewModels/HumidityGraphViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+class HumidityGraphViewModel: ObservableObject {
+    @Published var selectedFilter: String = "last_5min" {
+        didSet { fetch() }
+    }
+    @Published var points: [MonitoringPoint] = []
+    @Published var current: Double = 0
+    @Published var average: Double = 0
+    @Published var min: Double = 0
+    @Published var max: Double = 0
+    @Published var errorMessage: String?
+
+    let filters = ["last_5min", "24h", "last_week", "last_month", "last_3months"]
+
+    init() { fetch() }
+
+    func fetch() {
+        MonitoringService.shared.fetchHumidityGraph(filter: selectedFilter) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.points = data.points
+                    self?.current = data.current
+                    self?.average = data.average
+                    self?.min = data.min
+                    self?.max = data.max
+                case .failure(let error):
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    var chartValues: [Double] { points.map { $0.value } }
+
+    var xAxisLabels: [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "ha"
+        return points.map { formatter.string(from: $0.time) }
+    }
+}

--- a/NexStock1.0/ViewModels/MonitoringHomeViewModel.swift
+++ b/NexStock1.0/ViewModels/MonitoringHomeViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+class MonitoringHomeViewModel: ObservableObject {
+    @Published var temperature: Double = 0
+    @Published var humidity: Double = 0
+    @Published var notifications: [MonitoringNotification] = []
+    @Published var errorMessage: String?
+
+    func fetch() {
+        MonitoringService.shared.fetchHome { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.temperature = data.temperature
+                    self?.humidity = data.humidity
+                    self?.notifications = data.unread_notifications
+                case .failure(let error):
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}

--- a/NexStock1.0/ViewModels/TemperatureGraphViewModel.swift
+++ b/NexStock1.0/ViewModels/TemperatureGraphViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+class TemperatureGraphViewModel: ObservableObject {
+    @Published var selectedFilter: String = "last_5min" {
+        didSet { fetch() }
+    }
+    @Published var points: [MonitoringPoint] = []
+    @Published var current: Double = 0
+    @Published var average: Double = 0
+    @Published var min: Double = 0
+    @Published var max: Double = 0
+    @Published var errorMessage: String?
+
+    let filters = ["last_5min", "24h", "last_week", "last_month", "last_3months"]
+
+    init() { fetch() }
+
+    func fetch() {
+        MonitoringService.shared.fetchTemperatureGraph(filter: selectedFilter) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.points = data.points
+                    self?.current = data.current
+                    self?.average = data.average
+                    self?.min = data.min
+                    self?.max = data.max
+                case .failure(let error):
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    var chartValues: [Double] { points.map { $0.value } }
+
+    var xAxisLabels: [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "ha"
+        return points.map { formatter.string(from: $0.time) }
+    }
+}


### PR DESCRIPTION
## Summary
- add monitoring base URL
- create monitoring models and service for API data
- create view models to fetch home and graph data
- build views to show monitoring home, temperature and humidity graphs
- integrate new routes in navigation and menu

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift build` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685c79a37dec8327a4c890f5677c703a