### PR TITLE
Fix product cards and add auth header

### DIFF
--- a/NexStock1.0/Models/ProductModel+Conversion.swift
+++ b/NexStock1.0/Models/ProductModel+Conversion.swift
@@ -22,4 +22,15 @@ extension ProductModel {
             sensor_type: inventory.sensor_type ?? ""
         )
     }
+
+    init(from detailed: DetailedProductModel) {
+        self.init(
+            id: String(detailed.id),
+            name: detailed.name,
+            image_url: detailed.image_url,
+            stock_actual: 0,
+            category: "",
+            sensor_type: detailed.input_method.rawValue
+        )
+    }
 }

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -14,8 +14,12 @@ class ProductService {
 
     func fetchProducts(completion: @escaping (Result<[DetailedProductModel], Error>) -> Void) {
         guard let url = URL(string: baseURL) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
+        URLSession.shared.dataTask(with: request) { data, _, error in
             if let data = data {
                 if let jsonString = String(data: data, encoding: .utf8) {
                     print("🧾 JSON recibido: \(jsonString)")

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [InventoryProduct]
-    var onProductTap: (InventoryProduct) -> Void = { _ in }
+    var onProductTap: (ProductModel) -> Void = { _ in }
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
@@ -16,8 +16,9 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 20) {
                     ForEach(products) { product in
-                        HomeInventoryCardView(product: product) {
-                            onProductTap(product)
+                        let model = ProductModel(from: product)
+                        InventoryCardView(product: model) {
+                            onProductTap(model)
                         }
                     }
                 }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -42,27 +42,27 @@ struct HomeView: View {
                         if let summary = summaryVM.summary {
                             if let items = summary.expiring, !items.isEmpty {
                                 HomeSummarySectionView(title: "expiring".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = product
                                 }
                             }
                             if let items = summary.out_of_stock, !items.isEmpty {
                                 HomeSummarySectionView(title: "out_of_stock".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = product
                                 }
                             }
                             if let items = summary.low_stock, !items.isEmpty {
                                 HomeSummarySectionView(title: "below_minimum".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = product
                                 }
                             }
                             if let items = summary.near_minimum, !items.isEmpty {
                                 HomeSummarySectionView(title: "near_minimum".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = product
                                 }
                             }
                             if let items = summary.overstock, !items.isEmpty {
                                 HomeSummarySectionView(title: "overstock".localized, products: items) { product in
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = product
                                 }
                             }
                         }

--- a/NexStock1.0/View/InventoryCardView.swift
+++ b/NexStock1.0/View/InventoryCardView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InventoryCardView: View {
-    let product: DetailedProductModel
+    let product: ProductModel
     var onTap: (() -> Void)? = nil
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -16,7 +16,7 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        ProductCard(product: product) {
+                                        InventoryCardView(product: product) {
                                             onProductTap(product)
                                         }
                                         .onAppear {
@@ -34,35 +34,6 @@ struct InventoryGroupView: View {
         .onAppear {
             viewModel.fetchInitial()
         }
-    }
-}
-
-struct ProductCard: View {
-    let product: ProductModel
-    var onTap: () -> Void = {}
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            if let url = URL(string: product.image_url) {
-                AsyncImage(url: url) { image in
-                    image.resizable()
-                } placeholder: {
-                    ProgressView()
-                }
-                .frame(width: 120, height: 120)
-                .cornerRadius(8)
-            }
-            Text(product.name.localized)
-                .font(.headline)
-            Text("Stock: \(product.stock_actual)")
-                .font(.caption)
-            Text("Sensor: \(product.sensor_type.localized)")
-                .font(.caption)
-        }
-        .padding()
-        .background(Color.secondaryColor)
-        .cornerRadius(12)
-        .onTapGesture { onTap() }
     }
 }
 

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct InventoryHomeSectionView: View {
     let title: String
     /// Products to display within the section
-    let products: [DetailedProductModel]
+    let products: [ProductModel]
     /// Optional action triggered when the "Ver más" button is pressed
     var loadMore: (() -> Void)? = nil
     @EnvironmentObject var theme: ThemeManager

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -101,9 +101,10 @@ struct InventoryScreenView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                SearchProductCardView(product: product) {
+                                let model = ProductModel(from: product)
+                                InventoryCardView(product: model) {
                                     isSearchFocused = false
-                                    selectedProduct = ProductModel(from: product)
+                                    selectedProduct = model
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- unify UI for product lists using `InventoryCardView`
- allow `InventoryCardView` to accept `ProductModel`
- convert models to `ProductModel` when needed
- open product details from all lists
- send auth token in product requests

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ca1f856c48327a22de4b3d6b661f8