### PR TITLE
Apply auth token to inventory API calls

### DIFF
--- a/NexStock1.0/Services/InventoryService.swift
+++ b/NexStock1.0/Services/InventoryService.swift
@@ -7,7 +7,11 @@ class InventoryService {
     func fetchHomeSummary(limit: Int = 5, completion: @escaping (Result<InventoryHomeResponse, Error>) -> Void) {
         guard let url = URL(string: "\(baseURL)/inventory/home?limit=\(limit)") else { return }
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
             if let data = data {
                 do {
                     let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
@@ -24,7 +28,11 @@ class InventoryService {
     func fetchDetails(for name: String, completion: @escaping (Result<InventoryProduct, Error>) -> Void) {
         guard let url = URL(string: "\(baseURL)/inventory/home") else { return }
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
             if let data = data {
                 do {
                     let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)

--- a/NexStock1.0/ViewModels/InventoryHomeViewModel.swift
+++ b/NexStock1.0/ViewModels/InventoryHomeViewModel.swift
@@ -28,8 +28,12 @@ class InventoryHomeViewModel: ObservableObject {
             return
         }
 
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            let (data, _) = try await URLSession.shared.data(for: request)
             if let jsonString = String(data: data, encoding: .utf8) {
                 print("🧾 JSON recibido: \(jsonString)")
             }


### PR DESCRIPTION
## Summary
- add auth token headers to `InventoryService` requests
- secure `InventoryHomeViewModel` networking with bearer token

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b8aa4408327bd4bc60a4b557edb