### PR TITLE
Fix product card callbacks

### DIFF
--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -18,8 +18,8 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
                     ForEach(products) { product in
-                        InventoryCardView(product: ProductModel(from: searchProduct)) {
-                            selectedProduct = ProductModel(from: searchProduct)
+                        InventoryCardView(product: product) {
+                            onProductTap(product)
                         }
                     }
                 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -101,8 +101,8 @@ struct InventoryScreenView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                InventoryCardView(product: ProductModel(from: searchProduct)) {
-                                    selectedProduct = ProductModel(from: searchProduct)
+                                InventoryCardView(product: ProductModel(from: product)) {
+                                    selectedProduct = ProductModel(from: product)
                                 }
                             }
                         }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -14,7 +14,7 @@ class ProductDetailViewModel: ObservableObject {
                 switch result {
                 case .success(let detail):
                     self.detail = detail.product
-                    self.fetchMovements(for: idToUse)
+                    self.fetchMovements(id: idToUse)
                 case .failure(let error):
                     self.errorMessage = error.localizedDescription
                 }


### PR DESCRIPTION
## Summary
- correct `HomeSummarySectionView` tap handling
- fix `InventoryScreenView` search results taps

## Testing
- `swiftc -parse NexStock1.0/View/HomeSummarySectionView.swift`
- `swiftc -parse NexStock1.0/View/InventoryScreenView.swift`


------
https://chatgpt.com/codex/tasks/task_e_685db21a21f4832792e4ebeefbfb7215