### PR TITLE
Enable proper product detail handling

### DIFF
--- a/NexStock1.0/Models/ProductModel+Conversion.swift
+++ b/NexStock1.0/Models/ProductModel+Conversion.swift
@@ -3,13 +3,13 @@ import Foundation
 extension ProductModel {
     init(from search: SearchProduct) {
         self.init(
-            id: UUID().uuidString, // ID solo para SwiftUI
+            id: search.id,
             name: search.name,
             image_url: search.image_url,
             stock_actual: search.stock_actual,
             category: search.category,
             sensor_type: search.sensor_type,
-            realId: nil // porque no hay ID real
+            realId: search.id
         )
     }
 
@@ -31,7 +31,20 @@ extension ProductModel {
             image_url: detailed.image_url,
             stock_actual: 0,
             category: "",
-            sensor_type: detailed.input_method.rawValue
+            sensor_type: detailed.input_method.rawValue,
+            realId: String(detailed.id)
+        )
+    }
+
+    init(from detail: ProductDetailInfo) {
+        self.init(
+            id: detail.id,
+            name: detail.name,
+            image_url: detail.image_url ?? "",
+            stock_actual: detail.stock_actual ?? 0,
+            category: "",
+            sensor_type: "",
+            realId: detail.id
         )
     }
 }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 class ProductDetailViewModel: ObservableObject {
     @Published var detail: ProductDetailInfo?
+    @Published var product: ProductModel?
     @Published var movements: [ProductMovement] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
@@ -14,6 +15,7 @@ class ProductDetailViewModel: ObservableObject {
                 switch result {
                 case .success(let detail):
                     self.detail = detail.product
+                    self.product = ProductModel(from: detail.product)
                     self.fetchMovements(id: idToUse)
                 case .failure(let error):
                     self.errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- use backend IDs for `ProductModel` when converting from search
- convert detailed product info into `ProductModel`
- keep converted product inside `ProductDetailViewModel`

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbfa4819c832784b1ca79c4bdde5f