### PR TITLE
Fix product detail fetching and token handling

### DIFF
--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -10,13 +10,23 @@ struct ProductDetailResponse: Codable {
 struct ProductDetailInfo: Identifiable, Codable {
     let id: String
     let name: String
-    let brand: String?
-    let description: String?
     let image_url: String?
+    let description: String?
+    let brand: String?
+    let category: String?
     let stock_actual: Int?
-    let stock_min: Int?
-    let stock_max: Int?
-    let updated_at: String?
+    let stock_minimum: Int?
+    let stock_maximum: Int?
+    let sensor_type: String?
+    let last_updated: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, image_url, description, brand, category, stock_actual
+        case stock_minimum = "stock_min"
+        case stock_maximum = "stock_max"
+        case sensor_type
+        case last_updated = "updated_at"
+    }
 }
 
 /// Represents a single stock movement for a product

--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 struct SearchResultResponse: Codable {
-    let message: String
-    let total: Int
-    let results: [SearchProduct]
+    let message: String?
+    let product: SearchProduct
 }
 
 struct SearchProduct: Identifiable, Codable {

--- a/NexStock1.0/Services/InventoryService.swift
+++ b/NexStock1.0/Services/InventoryService.swift
@@ -5,46 +5,92 @@ class InventoryService {
     private let baseURL = NetworkConfig.inventoryBaseURL
 
     func fetchHomeSummary(limit: Int = 5, completion: @escaping (Result<InventoryHomeResponse, Error>) -> Void) {
+        guard let token = AuthService.shared.token else {
+            completion(.failure(NSError(domain: "InventoryService", code: 401, userInfo: [NSLocalizedDescriptionKey: "No token disponible."])))
+            return
+        }
         guard let url = URL(string: "\(baseURL)/inventory/home?limit=\(limit)") else { return }
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            if let data = data {
-                do {
-                    let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
-                    completion(.success(decoded))
-                } catch {
-                    completion(.failure(error))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let http = response as? HTTPURLResponse, let data = data else {
+                completion(.failure(NSError(domain: "InventoryService", code: 0, userInfo: nil)))
+                return
+            }
+
+            if http.statusCode != 200 {
+                if let msg = try? JSONDecoder().decode([String: String].self, from: data)["message"] {
+                    completion(.failure(NSError(domain: "InventoryService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: msg])))
+                } else {
+                    completion(.failure(NSError(domain: "InventoryService", code: http.statusCode, userInfo: nil)))
                 }
-            } else if let error = error {
+                return
+            }
+
+            do {
+                let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
+                completion(.success(decoded))
+            } catch {
                 completion(.failure(error))
             }
         }.resume()
     }
 
     func fetchDetails(for name: String, completion: @escaping (Result<InventoryProduct, Error>) -> Void) {
+        guard let token = AuthService.shared.token else {
+            completion(.failure(NSError(domain: "InventoryService", code: 401, userInfo: [NSLocalizedDescriptionKey: "No token disponible."])))
+            return
+        }
         guard let url = URL(string: "\(baseURL)/inventory/home") else { return }
 
-        URLSession.shared.dataTask(with: url) { data, _, error in
-            if let data = data {
-                do {
-                    let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
-                    let expiring = decoded.expiring ?? []
-                    let outOfStock = decoded.out_of_stock ?? []
-                    let lowStock = decoded.low_stock ?? []
-                    let nearMinimum = decoded.near_minimum ?? []
-                    let overstock = decoded.overstock ?? []
-                    let allItems = decoded.all ?? []
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-                    let all = expiring + outOfStock + lowStock + nearMinimum + overstock + allItems
-                    if let found = all.first(where: { $0.name.lowercased() == name.lowercased() }) {
-                        completion(.success(found))
-                    } else {
-                        completion(.failure(NSError(domain: "InventoryService", code: 404, userInfo: [NSLocalizedDescriptionKey: "Producto no encontrado"])))
-                    }
-                } catch {
-                    completion(.failure(error))
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let http = response as? HTTPURLResponse, let data = data else {
+                completion(.failure(NSError(domain: "InventoryService", code: 0, userInfo: nil)))
+                return
+            }
+
+            if http.statusCode != 200 {
+                if let msg = try? JSONDecoder().decode([String: String].self, from: data)["message"] {
+                    completion(.failure(NSError(domain: "InventoryService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: msg])))
+                } else {
+                    completion(.failure(NSError(domain: "InventoryService", code: http.statusCode, userInfo: nil)))
                 }
-            } else if let error = error {
+                return
+            }
+
+            do {
+                let decoded = try JSONDecoder().decode(InventoryHomeResponse.self, from: data)
+                let expiring = decoded.expiring ?? []
+                let outOfStock = decoded.out_of_stock ?? []
+                let lowStock = decoded.low_stock ?? []
+                let nearMinimum = decoded.near_minimum ?? []
+                let overstock = decoded.overstock ?? []
+                let allItems = decoded.all ?? []
+
+                let all = expiring + outOfStock + lowStock + nearMinimum + overstock + allItems
+                if let found = all.first(where: { $0.name.lowercased() == name.lowercased() }) {
+                    completion(.success(found))
+                } else {
+                    completion(.failure(NSError(domain: "InventoryService", code: 404, userInfo: [NSLocalizedDescriptionKey: "Producto no encontrado"])))
+                }
+            } catch {
                 completion(.failure(error))
             }
         }.resume()

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -75,12 +75,12 @@ struct ProductDetailView: View {
                         SettingRow(
                             icon: "arrowtriangle.up.fill",
                             title: "minimum_stock".localized,
-                            subtitle: detail.stock_min.map(String.init) ?? "no_information".localized
+                            subtitle: detail.stock_minimum.map(String.init) ?? "no_information".localized
                         )
                         SettingRow(
                             icon: "arrowtriangle.down.fill",
                             title: "maximum_stock".localized,
-                            subtitle: detail.stock_max.map(String.init) ?? "no_information".localized
+                            subtitle: detail.stock_maximum.map(String.init) ?? "no_information".localized
                         )
                         SettingRow(
                             icon: "tag.fill",
@@ -88,9 +88,19 @@ struct ProductDetailView: View {
                             subtitle: detail.brand?.isEmpty == false ? detail.brand! : "no_information".localized
                         )
                         SettingRow(
+                            icon: "square.stack.3d.up.fill",
+                            title: "category".localized,
+                            subtitle: detail.category ?? "no_information".localized
+                        )
+                        SettingRow(
+                            icon: "sensor.tag.radiowaves.forward",
+                            title: "sensor".localized,
+                            subtitle: detail.sensor_type ?? "no_information".localized
+                        )
+                        SettingRow(
                             icon: "clock.fill",
                             title: "last_updated".localized,
-                            subtitle: formattedDate(detail.updated_at)
+                            subtitle: formattedDate(detail.last_updated)
                         )
                         SettingRow(
                             icon: "text.bubble.fill",

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -7,6 +7,11 @@ class ProductDetailViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     func fetch(product: ProductModel) {
+        guard let _ = AuthService.shared.token else {
+            self.errorMessage = "No token disponible"
+            return
+        }
+
         let idToUse = product.realId ?? product.id
         ProductService.shared.fetchProductDetail(id: idToUse) { result in
             DispatchQueue.main.async {
@@ -23,6 +28,11 @@ class ProductDetailViewModel: ObservableObject {
     }
 
     private func fetchMovements(id: String) {
+        guard AuthService.shared.token != nil else {
+            self.errorMessage = "No token disponible"
+            return
+        }
+
         ProductService.shared.fetchProductMovements(id: id) { [weak self] result in
             DispatchQueue.main.async {
                 guard let self = self else { return }

--- a/NexStock1.0/ViewModels/ProductSearchViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductSearchViewModel.swift
@@ -25,12 +25,12 @@ class ProductSearchViewModel: ObservableObject {
         }
 
         isLoading = true
-        ProductService.shared.searchProducts(name: text) { [weak self] result in
+        ProductService.shared.searchProducts(query: text) { [weak self] result in
             DispatchQueue.main.async {
                 self?.isLoading = false
                 switch result {
-                case .success(let products):
-                    self?.results = products
+                case .success(let product):
+                    self?.results = [product]
                 case .failure:
                     self?.results = []
                 }


### PR DESCRIPTION
## Summary
- update models to match API fields
- centralize token validation when requesting products
- improve InventoryService with authorization header
- adjust product search to new `/search` behavior
- display more product details

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685dcf93b8fc83278f4ba6d29b406acd