### PR TITLE
Ensure product detail fetch before showing sheet

### DIFF
--- a/NexStock1.0/Models/ProductModel+Conversion.swift
+++ b/NexStock1.0/Models/ProductModel+Conversion.swift
@@ -9,7 +9,7 @@ extension ProductModel {
             stock_actual: search.stock_actual,
             category: search.category,
             sensor_type: search.sensor_type,
-            realId: nil // porque no hay ID real
+            realId: search.id // id real para poder obtener detalles
         )
     }
 

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -103,7 +103,7 @@ class ProductService {
     }
 
     // 🔍 Detalle individual de producto
-    func fetchProductDetail(id: String, completion: @escaping (Result<ProductDetailResponse, Error>) -> Void) {
+    func fetchProductDetail(id: String, completion: @escaping (Result<ProductDetailInfo, Error>) -> Void) {
         guard let url = URL(string: baseURL + "/" + id) else { return }
         guard let request = authorizedRequest(url: url) else {
             completion(.failure(NSError(domain: "ProductService", code: 401, userInfo: [NSLocalizedDescriptionKey: "No token disponible."])))
@@ -133,7 +133,7 @@ class ProductService {
             print("🧾 Detail JSON:", String(data: data, encoding: .utf8) ?? "")
             do {
                 let decoded = try JSONDecoder().decode(ProductDetailResponse.self, from: data)
-                completion(.success(decoded))
+                completion(.success(decoded.product))
             } catch {
                 completion(.failure(error))
             }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [ProductModel]
-    let onProductTap: (ProductModel) -> Void
 
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
@@ -19,11 +18,31 @@ struct HomeSummarySectionView: View {
                 HStack(spacing: 16) {
                     ForEach(products) { product in
                         InventoryCardView(product: product) {
-                            onProductTap(product)
+                            openDetail(for: product)
                         }
                     }
                 }
                 .padding(.horizontal)
+            }
+        }
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
+    }
+
+    @State private var selectedProduct: ProductDetailInfo? = nil
+
+    private func openDetail(for product: ProductModel) {
+        let idToUse = product.realId ?? product.id
+        ProductService.shared.fetchProductDetail(id: idToUse) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let detail):
+                    selectedProduct = detail
+                case .failure(let error):
+                    print("Error: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -13,7 +13,6 @@ struct HomeView: View {
     @StateObject private var summaryVM = HomeSummaryViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
-    @State private var selectedProduct: ProductModel? = nil
 
 
     var body: some View {
@@ -43,50 +42,35 @@ struct HomeView: View {
                             if let items = summary.expiring, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "expiring".localized,
-                                    products: items.map { ProductModel(from: $0) },
-                                    onProductTap: { product in
-                                        selectedProduct = product
-                                    }
+                                    products: items.map { ProductModel(from: $0) }
                                 )
                             }
 
                             if let items = summary.out_of_stock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "out_of_stock".localized,
-                                    products: items.map { ProductModel(from: $0) },
-                                    onProductTap: { product in
-                                        selectedProduct = product
-                                    }
+                                    products: items.map { ProductModel(from: $0) }
                                 )
                             }
 
                             if let items = summary.low_stock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "below_minimum".localized,
-                                    products: items.map { ProductModel(from: $0) },
-                                    onProductTap: { product in
-                                        selectedProduct = product
-                                    }
+                                    products: items.map { ProductModel(from: $0) }
                                 )
                             }
 
                             if let items = summary.near_minimum, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "near_minimum".localized,
-                                    products: items.map { ProductModel(from: $0) },
-                                    onProductTap: { product in
-                                        selectedProduct = product
-                                    }
+                                    products: items.map { ProductModel(from: $0) }
                                 )
                             }
 
                             if let items = summary.overstock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "overstock".localized,
-                                    products: items.map { ProductModel(from: $0) },
-                                    onProductTap: { product in
-                                        selectedProduct = product
-                                    }
+                                    products: items.map { ProductModel(from: $0) }
                                 )
                             }
                         }
@@ -103,10 +87,6 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
-        .sheet(item: $selectedProduct) { product in
-            ProductDetailView(product: product)
-                .environmentObject(localization)
-        }
         .task { summaryVM.fetchSummary() }
     }
 }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 
 struct InventoryGroupView: View {
-    var onProductTap: (ProductModel) -> Void
-
     @StateObject private var viewModel = PaginatedInventoryViewModel()
     @EnvironmentObject var localization: LocalizationManager
+    @State private var selectedProduct: ProductDetailInfo? = nil
 
     var body: some View {
         ScrollView {
@@ -21,7 +20,7 @@ struct InventoryGroupView: View {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
                                         InventoryCardView(product: product) {
-                                            onProductTap(product)
+                                            openDetail(for: product)
                                         }
                                         .onAppear {
                                             viewModel.loadMoreIfNeeded(currentItem: product, category: category)
@@ -38,6 +37,24 @@ struct InventoryGroupView: View {
         }
         .onAppear {
             viewModel.fetchInitial()
+        }
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
+    }
+
+    private func openDetail(for product: ProductModel) {
+        let idToUse = product.realId ?? product.id
+        ProductService.shared.fetchProductDetail(id: idToUse) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let detail):
+                    selectedProduct = detail
+                case .failure(let error):
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
         }
     }
 }

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -5,7 +5,7 @@ struct InventoryHomeSectionView: View {
     let products: [ProductModel]
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
-    @State private var selectedProduct: ProductModel? = nil
+    @State private var selectedProduct: ProductDetailInfo? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -18,7 +18,7 @@ struct InventoryHomeSectionView: View {
                 HStack(spacing: 16) {
                     ForEach(products) { product in
                         InventoryCardView(product: product) {
-                            selectedProduct = product
+                            openDetail(for: product)
                         }
                     }
                 }
@@ -28,6 +28,20 @@ struct InventoryHomeSectionView: View {
         .sheet(item: $selectedProduct) { product in
             ProductDetailView(product: product)
                 .environmentObject(localization)
+        }
+    }
+
+    private func openDetail(for product: ProductModel) {
+        let idToUse = product.realId ?? product.id
+        ProductService.shared.fetchProductDetail(id: idToUse) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let detail):
+                    selectedProduct = detail
+                case .failure(let error):
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
         }
     }
 }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ProductDetailView: View {
-    let product: ProductModel
+    let product: ProductDetailInfo
     @StateObject private var viewModel = ProductDetailViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @Environment(\.dismiss) var dismiss
@@ -36,7 +36,10 @@ struct ProductDetailView: View {
             }
             .navigationTitle(product.name.localized)
             .navigationBarTitleDisplayMode(.inline)
-            .onAppear { viewModel.fetch(product: product) }
+            .onAppear {
+                viewModel.detail = product
+                viewModel.fetchMovements(for: product.id)
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("close".localized) { dismiss() }
@@ -213,7 +216,7 @@ struct ProductDetailView: View {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailView(product: ProductModel(id: "1", name: "Apple", image_url: "", stock_actual: 0, category: "Alimentos", sensor_type: "temperature"))
+        ProductDetailView(product: ProductDetailInfo(id: "1", name: "Apple", image_url: nil, description: nil, brand: nil, category: nil, stock_actual: 0, stock_minimum: 0, stock_maximum: 0, sensor_type: nil, last_updated: nil))
             .environmentObject(LocalizationManager())
     }
 }

--- a/NexStock1.0/ViewModels/ProductDetailViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductDetailViewModel.swift
@@ -18,8 +18,8 @@ class ProductDetailViewModel: ObservableObject {
                 self.isLoading = false
                 switch result {
                 case .success(let detail):
-                    self.detail = detail.product
-                    self.fetchMovements(id: idToUse)
+                    self.detail = detail
+                    self.fetchMovements(for: idToUse)
                 case .failure(let error):
                     self.errorMessage = error.localizedDescription
                 }
@@ -27,7 +27,7 @@ class ProductDetailViewModel: ObservableObject {
         }
     }
 
-    private func fetchMovements(id: String) {
+    func fetchMovements(for id: String) {
         guard AuthService.shared.token != nil else {
             self.errorMessage = "No token disponible"
             return


### PR DESCRIPTION
## Summary
- use actual search result ID when converting to ProductModel
- return `ProductDetailInfo` directly from `fetchProductDetail`
- allow fetching movements without reloading detail
- pass detailed product into `ProductDetailView`
- fetch detail on tap in all inventory-related views
- simplify HomeView since sections handle detail loading themselves

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685dd42ae3a48327bb296df96ac55ab7