### PR TITLE
Fix product search card behavior

### DIFF
--- a/NexStock1.0/View/HomeInventoryCardView.swift
+++ b/NexStock1.0/View/HomeInventoryCardView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Wrapper around InventoryCardView used in the Home screens.
+/// Allows reusing the same style in other places like search results.
+struct HomeInventoryCardView: View {
+    let product: ProductModel
+    var onTap: (() -> Void)? = nil
+
+    var body: some View {
+        InventoryCardView(product: product, onTap: onTap)
+    }
+}
+
+#Preview {
+    HomeInventoryCardView(product: ProductModel(id: "1", name: "Demo", image_url: "", stock_actual: 10, category: "", sensor_type: ""))
+        .environmentObject(ThemeManager())
+        .environmentObject(LocalizationManager())
+}

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -17,7 +17,7 @@ struct HomeSummarySectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
+                        HomeInventoryCardView(product: product) {
                             openDetail(for: product)
                         }
                     }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -19,7 +19,7 @@ struct InventoryGroupView: View {
                             ScrollView(.horizontal, showsIndicators: false) {
                                 HStack(spacing: 16) {
                                     ForEach(items) { product in
-                                        InventoryCardView(product: product) {
+                                        HomeInventoryCardView(product: product) {
                                             openDetail(for: product)
                                         }
                                         .onAppear {

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -17,7 +17,7 @@ struct InventoryHomeSectionView: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
                     ForEach(products) { product in
-                        InventoryCardView(product: product) {
+                        HomeInventoryCardView(product: product) {
                             openDetail(for: product)
                         }
                     }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -100,7 +100,7 @@ struct InventoryScreenView: View {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
                                 let model = ProductModel(from: product)
-                                InventoryCardView(product: model) {
+                                HomeInventoryCardView(product: model) {
                                     openDetail(for: model)
                                 }
                             }


### PR DESCRIPTION
## Summary
- add a `HomeInventoryCardView` wrapper for reuse
- use `HomeInventoryCardView` in home sections and inventory screens
- reuse the same card when listing inventory groups

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f179eb6ac83278ba4ccc8c6deab3b