### PR TITLE
Fix search results and detail screens

### DIFF
--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct SearchResultResponse: Codable {
     let message: String?
-    let product: SearchProduct
+    let products: [SearchProduct]
 }
 
 struct SearchProduct: Identifiable, Codable {

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -178,7 +178,7 @@ class ProductService {
     }
 
     // 🔎 Búsqueda por nombre
-    func searchProducts(query: String, completion: @escaping (Result<SearchProduct, Error>) -> Void) {
+    func searchProducts(query: String, completion: @escaping (Result<[SearchProduct], Error>) -> Void) {
         var components = URLComponents(string: baseURL + "/search")
         components?.queryItems = [
             URLQueryItem(name: "query", value: query)
@@ -213,7 +213,7 @@ class ProductService {
             print("🧾 Search JSON:", String(data: data, encoding: .utf8) ?? "")
             do {
                 let decoded = try JSONDecoder().decode(SearchResultResponse.self, from: data)
-                completion(.success(decoded.product))
+                completion(.success(decoded.products))
             } catch {
                 completion(.failure(error))
             }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -40,6 +40,7 @@ struct HomeSummarySectionView: View {
                 switch result {
                 case .success(let detail):
                     selectedProduct = detail
+                    print("\u{1F4E6} Producto seleccionado:", detail)
                 case .failure(let error):
                     print("Error: \(error.localizedDescription)")
                 }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -51,6 +51,7 @@ struct InventoryGroupView: View {
                 switch result {
                 case .success(let detail):
                     selectedProduct = detail
+                    print("\u{1F4E6} Producto seleccionado:", detail)
                 case .failure(let error):
                     print("Error: \(error.localizedDescription)")
                 }

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -38,6 +38,7 @@ struct InventoryHomeSectionView: View {
                 switch result {
                 case .success(let detail):
                     selectedProduct = detail
+                    print("\u{1F4E6} Producto seleccionado:", detail)
                 case .failure(let error):
                     print("Error: \(error.localizedDescription)")
                 }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -135,6 +135,7 @@ struct InventoryScreenView: View {
                 switch result {
                 case .success(let detail):
                     selectedProduct = detail
+                    print("\u{1F4E6} Producto seleccionado:", detail)
                 case .failure(let error):
                     print("Error: \(error.localizedDescription)")
                 }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -131,7 +131,7 @@ struct ProductDetailView: View {
                     .padding()
             } else {
                 VStack(spacing: 12) {
-                    ForEach(viewModel.movements) { move in
+                    ForEach(Array(viewModel.movements.enumerated()), id: \.offset) { _, move in
                         MovementRow(move: move)
                     }
                 }

--- a/NexStock1.0/ViewModels/ProductSearchViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductSearchViewModel.swift
@@ -29,8 +29,8 @@ class ProductSearchViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self?.isLoading = false
                 switch result {
-                case .success(let product):
-                    self?.results = [product]
+                case .success(let products):
+                    self?.results = products
                 case .failure:
                     self?.results = []
                 }


### PR DESCRIPTION
## Summary
- decode multiple products in search result
- return arrays in search service
- handle array results in search view model
- print selected product when opening details

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f1b3181b08327975defdd5d20857c