### PR TITLE
Implement product detail fetch and update views

### DIFF
--- a/NexStock1.0/Models/ProductModel+Conversion.swift
+++ b/NexStock1.0/Models/ProductModel+Conversion.swift
@@ -34,6 +34,17 @@ extension ProductModel {
             sensor_type: detailed.input_method.rawValue
         )
     }
+
+    init(from info: ProductDetailInfo) {
+        self.init(
+            id: info.id,
+            name: info.name,
+            image_url: info.image_url ?? "",
+            stock_actual: info.stock_actual ?? 0,
+            category: info.category ?? "",
+            sensor_type: info.sensor_type ?? ""
+        )
+    }
 }
 
 struct ProductResponse: Codable {

--- a/NexStock1.0/Services/ProductService.swift
+++ b/NexStock1.0/Services/ProductService.swift
@@ -140,6 +140,33 @@ class ProductService {
         }.resume()
     }
 
+    func fetchProductDetail(by id: String, completion: @escaping (Result<ProductModel, Error>) -> Void) {
+        guard let url = URL(string: "https://inventory.nexusutd.online/inventory/products/\(id)") else { return }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(ProductDetailResponse.self, from: data)
+                    let converted = ProductModel(from: decoded.product)
+                    DispatchQueue.main.async {
+                        completion(.success(converted))
+                    }
+                } catch {
+                    DispatchQueue.main.async {
+                        completion(.failure(error))
+                    }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    completion(.failure(error ?? URLError(.badServerResponse)))
+                }
+            }
+        }.resume()
+    }
+
     // 📦 Historial de movimientos
     func fetchProductMovements(id: String, completion: @escaping (Result<[ProductMovement], Error>) -> Void) {
         guard let url = URL(string: baseURL + "/" + id + "/movements") else { return }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -31,19 +31,15 @@ struct HomeSummarySectionView: View {
         }
     }
 
-    @State private var selectedProduct: ProductDetailInfo? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     private func openDetail(for product: ProductModel) {
-        let idToUse = product.realId ?? product.id
-        ProductService.shared.fetchProductDetail(id: idToUse) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let detail):
-                    selectedProduct = detail
-                    print("\u{1F4E6} Producto seleccionado:", detail)
-                case .failure(let error):
-                    print("Error: \(error.localizedDescription)")
-                }
+        ProductService.shared.fetchProductDetail(by: product.id) { result in
+            switch result {
+            case .success(let fullProduct):
+                selectedProduct = fullProduct
+            case .failure(let error):
+                print("\u{274C} Error al obtener detalles: \(error)")
             }
         }
     }

--- a/NexStock1.0/View/InventoryGroupView.swift
+++ b/NexStock1.0/View/InventoryGroupView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct InventoryGroupView: View {
     @StateObject private var viewModel = PaginatedInventoryViewModel()
     @EnvironmentObject var localization: LocalizationManager
-    @State private var selectedProduct: ProductDetailInfo? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         ScrollView {
@@ -45,16 +45,12 @@ struct InventoryGroupView: View {
     }
 
     private func openDetail(for product: ProductModel) {
-        let idToUse = product.realId ?? product.id
-        ProductService.shared.fetchProductDetail(id: idToUse) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let detail):
-                    selectedProduct = detail
-                    print("\u{1F4E6} Producto seleccionado:", detail)
-                case .failure(let error):
-                    print("Error: \(error.localizedDescription)")
-                }
+        ProductService.shared.fetchProductDetail(by: product.id) { result in
+            switch result {
+            case .success(let fullProduct):
+                selectedProduct = fullProduct
+            case .failure(let error):
+                print("\u{274C} Error al obtener detalles: \(error)")
             }
         }
     }

--- a/NexStock1.0/View/InventoryHomeSectionView.swift
+++ b/NexStock1.0/View/InventoryHomeSectionView.swift
@@ -5,7 +5,7 @@ struct InventoryHomeSectionView: View {
     let products: [ProductModel]
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
-    @State private var selectedProduct: ProductDetailInfo? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -32,16 +32,12 @@ struct InventoryHomeSectionView: View {
     }
 
     private func openDetail(for product: ProductModel) {
-        let idToUse = product.realId ?? product.id
-        ProductService.shared.fetchProductDetail(id: idToUse) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let detail):
-                    selectedProduct = detail
-                    print("\u{1F4E6} Producto seleccionado:", detail)
-                case .failure(let error):
-                    print("Error: \(error.localizedDescription)")
-                }
+        ProductService.shared.fetchProductDetail(by: product.id) { result in
+            switch result {
+            case .success(let fullProduct):
+                selectedProduct = fullProduct
+            case .failure(let error):
+                print("\u{274C} Error al obtener detalles: \(error)")
             }
         }
     }

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -20,7 +20,7 @@ struct InventoryScreenView: View {
     @StateObject private var searchVM = ProductSearchViewModel()
     @FocusState private var isSearchFocused: Bool
     @State private var showAddProductSheet = false
-    @State private var selectedProduct: ProductDetailInfo? = nil
+    @State private var selectedProduct: ProductModel? = nil
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -129,16 +129,12 @@ struct InventoryScreenView: View {
     }
 
     private func openDetail(for product: ProductModel) {
-        let idToUse = product.realId ?? product.id
-        ProductService.shared.fetchProductDetail(id: idToUse) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let detail):
-                    selectedProduct = detail
-                    print("\u{1F4E6} Producto seleccionado:", detail)
-                case .failure(let error):
-                    print("Error: \(error.localizedDescription)")
-                }
+        ProductService.shared.fetchProductDetail(by: product.id) { result in
+            switch result {
+            case .success(let fullProduct):
+                selectedProduct = fullProduct
+            case .failure(let error):
+                print("\u{274C} Error al obtener detalles: \(error)")
             }
         }
     }

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ProductDetailView: View {
-    let product: ProductDetailInfo
+    let product: ProductModel
     @StateObject private var viewModel = ProductDetailViewModel()
     @EnvironmentObject var localization: LocalizationManager
     @Environment(\.dismiss) var dismiss
@@ -36,10 +36,7 @@ struct ProductDetailView: View {
             }
             .navigationTitle(product.name.localized)
             .navigationBarTitleDisplayMode(.inline)
-            .onAppear {
-                viewModel.detail = product
-                viewModel.fetchMovements(for: product.id)
-            }
+            .onAppear { viewModel.fetch(product: product) }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("close".localized) { dismiss() }
@@ -216,7 +213,7 @@ struct ProductDetailView: View {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailView(product: ProductDetailInfo(id: "1", name: "Apple", image_url: nil, description: nil, brand: nil, category: nil, stock_actual: 0, stock_minimum: 0, stock_maximum: 0, sensor_type: nil, last_updated: nil))
+        ProductDetailView(product: ProductModel(id: "1", name: "Apple", image_url: "", stock_actual: 0, category: "Alimentos", sensor_type: "temperature"))
             .environmentObject(LocalizationManager())
     }
 }


### PR DESCRIPTION
## Summary
- add conversion initializer from `ProductDetailInfo` to `ProductModel`
- expose new `fetchProductDetail(by:)` in `ProductService`
- open product detail sheets with `ProductModel`
- update detail view to accept `ProductModel`

## Testing
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f25ef4d588327b9a1ea1dea205cb5