### PR TITLE
Implement new product search

### DIFF
--- a/NexStock1.0/Models/SearchModels.swift
+++ b/NexStock1.0/Models/SearchModels.swift
@@ -5,6 +5,11 @@ struct SearchResultResponse: Codable {
     let products: [SearchProduct]
 }
 
+/// Response for the new search endpoint
+struct SearchProductsResponse: Codable {
+    let results: [SearchProduct]
+}
+
 struct SearchProduct: Identifiable, Codable {
     /// Puede venir nulo si el producto no existe en inventario
     let id: String?

--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -99,9 +99,8 @@ struct InventoryScreenView: View {
                     } else {
                         LazyVStack(alignment: .leading, spacing: 16) {
                             ForEach(searchVM.results) { product in
-                                let model = ProductModel(from: product)
-                                InventoryCardView(product: model) {
-                                    openDetail(for: model)
+                                InventoryCardView(product: product) {
+                                    openDetail(for: product)
                                 }
                             }
                         }

--- a/NexStock1.0/ViewModels/ProductSearchViewModel.swift
+++ b/NexStock1.0/ViewModels/ProductSearchViewModel.swift
@@ -3,7 +3,7 @@ import Combine
 
 class ProductSearchViewModel: ObservableObject {
     @Published var query: String = ""
-    @Published var results: [SearchProduct] = []
+    @Published var results: [ProductModel] = []
     @Published var isLoading: Bool = false
 
     private var cancellables = Set<AnyCancellable>()
@@ -25,15 +25,10 @@ class ProductSearchViewModel: ObservableObject {
         }
 
         isLoading = true
-        ProductService.shared.searchProducts(query: text) { [weak self] result in
+        ProductService.shared.searchProducts(name: text) { [weak self] products in
             DispatchQueue.main.async {
                 self?.isLoading = false
-                switch result {
-                case .success(let products):
-                    self?.results = products
-                case .failure:
-                    self?.results = []
-                }
+                self?.results = products
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `SearchProductsResponse` for new endpoint
- return `ProductModel` objects from `searchProducts`
- update `ProductSearchViewModel` to use new service
- adjust `InventoryScreenView` to display `ProductModel` search results

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f2c80e75c83279934549fd14fd2e4