### PR TITLE
Fix product detail data model

### DIFF
--- a/NexStock1.0/Models/ProductDetailResponse.swift
+++ b/NexStock1.0/Models/ProductDetailResponse.swift
@@ -1,32 +1,22 @@
 import Foundation
 
 struct ProductDetailResponse: Codable {
-    let message: String?
+    let message: String
     let product: ProductDetailInfo
-    /// Movements may be absent in the response so make it optional
-    let movements: [ProductMovement]?
 }
 
 struct ProductDetailInfo: Identifiable, Codable {
     let id: String
     let name: String
-    let image_url: String?
+    let image_url: String
     let description: String?
-    let brand: String?
     let category: String?
+    let brand: String?
     let stock_actual: Int?
     let stock_minimum: Int?
     let stock_maximum: Int?
-    let sensor_type: String?
     let last_updated: String?
-
-    enum CodingKeys: String, CodingKey {
-        case id, name, image_url, description, brand, category, stock_actual
-        case stock_minimum = "stock_min"
-        case stock_maximum = "stock_max"
-        case sensor_type
-        case last_updated = "updated_at"
-    }
+    let sensor_type: String?
 }
 
 /// Represents a single stock movement for a product

--- a/NexStock1.0/View/ProductDetailView.swift
+++ b/NexStock1.0/View/ProductDetailView.swift
@@ -52,8 +52,7 @@ struct ProductDetailView: View {
         ScrollView {
             if let detail = viewModel.detail {
                 VStack(spacing: 16) {
-                    if let urlString = detail.image_url,
-                       let url = URL(string: urlString) {
+                    if let url = URL(string: detail.image_url) {
                         AsyncImage(url: url) { image in
                             image.resizable()
                                 .scaledToFit()
@@ -216,7 +215,7 @@ struct ProductDetailView: View {
 
 struct ProductDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        ProductDetailView(product: ProductDetailInfo(id: "1", name: "Apple", image_url: nil, description: nil, brand: nil, category: nil, stock_actual: 0, stock_minimum: 0, stock_maximum: 0, sensor_type: nil, last_updated: nil))
+        ProductDetailView(product: ProductDetailInfo(id: "1", name: "Apple", image_url: "", description: nil, category: nil, brand: nil, stock_actual: 0, stock_minimum: 0, stock_maximum: 0, last_updated: nil, sensor_type: nil))
             .environmentObject(LocalizationManager())
     }
 }


### PR DESCRIPTION
## Summary
- align `ProductDetailInfo` with backend JSON
- update product detail preview and view to use required `image_url`

## Testing
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3789d5608327a1c2780089340d64