### PR TITLE
Add SensorChartView for adaptive sensor graphs

### DIFF
--- a/NexStock1.0/View/HumidityView.swift
+++ b/NexStock1.0/View/HumidityView.swift
@@ -48,9 +48,10 @@ struct HumidityView: View {
                                     .foregroundColor(.tertiaryColor)
                                     .frame(maxWidth: .infinity, alignment: .center)
                             } else {
-                                LineChartView(
-                                    data: viewModel.chartValues,
-                                    labels: viewModel.xAxisLabels
+                                SensorChartView(
+                                    data: viewModel.sensorPoints,
+                                    mode: viewModel.chartMode,
+                                    type: .humidity
                                 )
                             }
                         }

--- a/NexStock1.0/View/SensorChartView.swift
+++ b/NexStock1.0/View/SensorChartView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Chart view that adapts axis labels and ranges depending on the selected range
+/// and the type of sensor displayed.
+struct SensorChartView: View {
+    let data: [SensorDataPoint]
+    let mode: ChartRangeMode
+    let type: SensorType
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Chart {
+                ForEach(data) { point in
+                    LineMark(
+                        x: .value("Tiempo", point.timestamp),
+                        y: .value("Valor", point.value)
+                    )
+                    .interpolationMethod(.catmullRom)
+                    .foregroundStyle(type == .temperature ? .red : .blue)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                }
+            }
+            .chartXAxis {
+                AxisMarks(values: .automatic(desiredCount: axisLabelCount)) { value in
+                    AxisValueLabel() {
+                        if let date = value.as(Date.self) {
+                            Text(axisLabelFormatter.string(from: date))
+                                .font(.caption2)
+                                .rotationEffect(.degrees(-45))
+                        }
+                    }
+                }
+            }
+            .chartYScale(domain: yAxisRange)
+            .frame(height: 200)
+            .padding(.horizontal)
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.secondaryColor)
+            )
+            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+        }
+    }
+
+    // MARK: - Helpers
+
+    var axisLabelCount: Int {
+        switch mode {
+        case .last5min: return 8
+        case .day: return 12
+        case .week: return 7
+        case .month: return 10
+        case .months3: return 9
+        }
+    }
+
+    var axisLabelFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        switch mode {
+        case .last5min: formatter.dateFormat = "HH:mm:ss"
+        case .day: formatter.dateFormat = "HH:mm"
+        case .week: formatter.dateFormat = "E ha"
+        case .month: formatter.dateFormat = "d MMM"
+        case .months3: formatter.dateFormat = "MMM"
+        }
+        return formatter
+    }
+
+    var yAxisRange: ClosedRange<Double> {
+        let values = data.map(\.value)
+        guard let min = values.min(), let max = values.max() else {
+            return 0...1
+        }
+        let padding = (max - min) * 0.1
+        return (min - padding)...(max + padding)
+    }
+}
+
+enum ChartRangeMode {
+    case last5min, day, week, month, months3
+}
+
+enum SensorType {
+    case temperature, humidity
+}
+
+struct SensorDataPoint: Identifiable {
+    let id = UUID()
+    let timestamp: Date
+    let value: Double
+}
+

--- a/NexStock1.0/View/TemperatureView.swift
+++ b/NexStock1.0/View/TemperatureView.swift
@@ -48,9 +48,10 @@ struct TemperatureView: View {
                                     .foregroundColor(.tertiaryColor)
                                     .frame(maxWidth: .infinity, alignment: .center)
                             } else {
-                                LineChartView(
-                                    data: viewModel.chartValues,
-                                    labels: viewModel.xAxisLabels
+                                SensorChartView(
+                                    data: viewModel.sensorPoints,
+                                    mode: viewModel.chartMode,
+                                    type: .temperature
                                 )
                             }
                         }

--- a/NexStock1.0/ViewModels/HumidityViewModel.swift
+++ b/NexStock1.0/ViewModels/HumidityViewModel.swift
@@ -59,6 +59,21 @@ class HumidityViewModel: ObservableObject {
         return humidityData.map { formatter.string(from: $0.time) }
     }
 
+    // Data for the Swift Charts based view
+    var sensorPoints: [SensorDataPoint] {
+        humidityData.map { SensorDataPoint(timestamp: $0.time, value: $0.value) }
+    }
+
+    var chartMode: ChartRangeMode {
+        switch selectedTimeRange {
+        case "last_5min": return .last5min
+        case "last_week": return .week
+        case "last_month": return .month
+        case "last_3months": return .months3
+        default: return .day
+        }
+    }
+
     var optimalMax: Double {
         70.0
     }

--- a/NexStock1.0/ViewModels/TemperatureViewModel.swift
+++ b/NexStock1.0/ViewModels/TemperatureViewModel.swift
@@ -56,6 +56,21 @@ class TemperatureViewModel: ObservableObject {
         return temperatureData.map { formatter.string(from: $0.time) }
     }
 
+    // Data for the Swift Charts based view
+    var sensorPoints: [SensorDataPoint] {
+        temperatureData.map { SensorDataPoint(timestamp: $0.time, value: $0.value) }
+    }
+
+    var chartMode: ChartRangeMode {
+        switch selectedTimeRange {
+        case "last_5min": return .last5min
+        case "last_week": return .week
+        case "last_month": return .month
+        case "last_3months": return .months3
+        default: return .day
+        }
+    }
+
     var optimalMax: Double {
         27.0
     }


### PR DESCRIPTION
## Summary
- add new `SensorChartView` capable of adjusting axes per selected range
- expose `ChartRangeMode` and `SensorType` enums plus `SensorDataPoint`
- update temperature and humidity view models to supply chart data and mode
- use `SensorChartView` in `TemperatureView` and `HumidityView`

## Testing
- `swift --version`
- `swift test list` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3d733b7883278f6964968f8cee07