### PR TITLE
Add notifications fetch and display

### DIFF
--- a/NexStock1.0/Models/NotificationModel.swift
+++ b/NexStock1.0/Models/NotificationModel.swift
@@ -1,0 +1,20 @@
+struct NotificationModel: Identifiable, Codable {
+    let id: String
+    let sensor: String
+    let message: String
+    let timestamp: String
+    let status: String
+}
+
+struct NotificationsResponse: Codable {
+    let message: String
+    let notifications: [NotificationModel]
+    let pagination: PaginationInfo
+}
+
+struct PaginationInfo: Codable {
+    let current_page: Int
+    let total_pages: Int
+    let next_page: Int?
+    let limit: Int
+}

--- a/NexStock1.0/Services/NotificationService.swift
+++ b/NexStock1.0/Services/NotificationService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+class NotificationService {
+    static let shared = NotificationService()
+
+    func fetchNotifications(limit: Int = 20, completion: @escaping ([NotificationModel]) -> Void) {
+        guard let url = URL(string: "https://monitoring.nexusutd.online/monitoring/notifications?sensor_type=all&read_status=all&page=1&limit=\(limit)") else {
+            completion([])
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(NotificationsResponse.self, from: data)
+                    DispatchQueue.main.async {
+                        completion(decoded.notifications)
+                    }
+                } catch {
+                    print("❌ Error decoding: \(error)")
+                    completion([])
+                }
+            } else {
+                completion([])
+            }
+        }.resume()
+    }
+}

--- a/NexStock1.0/Utils/Date+Formatting.swift
+++ b/NexStock1.0/Utils/Date+Formatting.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+func formattedDate(from isoString: String) -> String {
+    let formatter = ISO8601DateFormatter()
+    if let date = formatter.date(from: isoString) {
+        let output = DateFormatter()
+        output.dateFormat = "dd MMM yyyy, HH:mm"
+        return output.string(from: date)
+    }
+    return isoString
+}


### PR DESCRIPTION
## Summary
- add NotificationModel and response structures
- add NotificationService to call notification endpoint
- show three most recent notifications in MonitoringHomeView
- add helper to format ISO dates

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f49d663308327a14d0db712f11bca