### PR TITLE
Add alert notification fetching and display

### DIFF
--- a/NexStock1.0/Models/AlertNotification.swift
+++ b/NexStock1.0/Models/AlertNotification.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct AlertNotification: Identifiable, Codable {
+    let id: String
+    let sensor: String
+    let message: String
+    let timestamp: String
+    let status: String
+}
+
+struct AlertNotificationResponse: Codable {
+    let message: String
+    let notifications: [AlertNotification]
+    let pagination: PaginationData
+}
+
+struct PaginationData: Codable {
+    let current_page: Int
+    let total_pages: Int
+    let next_page: Int
+    let limit: Int
+}

--- a/NexStock1.0/Services/AlertService.swift
+++ b/NexStock1.0/Services/AlertService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+class AlertService {
+    static let shared = AlertService()
+    private let baseURL = "https://monitoring.nexusutd.online/monitoring"
+
+    func fetchNotifications(limit: Int = 20, completion: @escaping ([AlertNotification]) -> Void) {
+        guard let url = URL(string: "\(baseURL)/notifications?sensor_type=all&read_status=all&page=1&limit=\(limit)") else {
+            completion([])
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(AuthService.shared.token ?? "")", forHTTPHeaderField: "Authorization")
+
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            if let data = data {
+                do {
+                    let decoded = try JSONDecoder().decode(AlertNotificationResponse.self, from: data)
+                    DispatchQueue.main.async {
+                        completion(decoded.notifications)
+                    }
+                } catch {
+                    print("❌ Decoding error: \(error)")
+                    completion([])
+                }
+            } else {
+                completion([])
+            }
+        }.resume()
+    }
+}

--- a/NexStock1.0/View/AlertCardView.swift
+++ b/NexStock1.0/View/AlertCardView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct AlertCardView: View {
+    let alert: AlertNotification
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(alert.sensor)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+            Text(alert.message)
+                .font(.body)
+                .foregroundColor(.tertiaryColor)
+            Text(alert.timestamp)
+                .font(.caption)
+                .foregroundColor(.tertiaryColor.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color.secondaryColor)
+        .cornerRadius(12)
+        .shadow(radius: 2)
+    }
+}

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -13,11 +13,7 @@ struct AlertView: View {
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var theme: ThemeManager
 
-    let alerts: [AlertModel] = [
-        .init(sensor: "Sensor de movimiento", message: "Se ha detectado una vibración fuerte en la zona A.", time: "13:42", icon: "exclamationmark.triangle.fill", severity: .high),
-        .init(sensor: "Sensor de gases", message: "Alta concentración de gas detectada en la cocina.", time: "12:10", icon: "exclamationmark.triangle.fill", severity: .medium),
-        .init(sensor: "Sensor de humedad", message: "Aumento repentino de humedad detectado.", time: "2 de junio", icon: "exclamationmark.triangle.fill", severity: .low)
-    ]
+    @State private var alerts: [AlertNotification] = []
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -33,36 +29,8 @@ struct AlertView: View {
                 ScrollView {
                     VStack(spacing: 12) {
                         ForEach(alerts) { alert in
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: alert.icon)
-                                    .foregroundColor(alert.severity.color)
-                                    .font(.system(size: 18))
-                                    .padding(.top, 2)
-
-                                VStack(alignment: .leading, spacing: 4) {
-                                    HStack {
-                                        Text(alert.sensor)
-                                            .fontWeight(.semibold)
-                                        Spacer()
-                                        Text(alert.time)
-                                            .foregroundColor(.gray)
-                                            .font(.caption)
-                                    }
-
-                                    Text(alert.message)
-                                        .font(.body)
-                                }
-                                .padding(12)
-                                .background(
-                                    LinearGradient(
-                                        colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
-                                        startPoint: .topLeading,
-                                        endPoint: .bottomTrailing
-                                    )
-                                )
-                                .cornerRadius(10)
-                            }
-                            .padding(.horizontal)
+                            AlertCardView(alert: alert)
+                                .padding(.horizontal)
                         }
                     }
                     .padding(.top, 10)
@@ -77,5 +45,10 @@ struct AlertView: View {
         }
         .animation(.easeInOut, value: showMenu)
         .navigationBarBackButtonHidden(true)
+        .task {
+            AlertService.shared.fetchNotifications(limit: 100) { fetched in
+                alerts = fetched
+            }
+        }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- define `AlertNotification` models
- add `AlertService` to query notifications
- show latest alerts on `HomeView`
- list all alerts in `AlertView`
- create reusable `AlertCardView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e56079483278a0004f2fd912e08