### PR TITLE
Reuse alert card component

### DIFF
--- a/NexStock1.0/View/AlertCardView.swift
+++ b/NexStock1.0/View/AlertCardView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct AlertCardView: View {
+    let alert: AlertModel
+    @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: alert.icon)
+                .foregroundColor(alert.severity.color)
+                .font(.title2)
+
+            Text(alert.message)
+                .font(.subheadline)
+                .foregroundColor(.tertiaryColor)
+                .multilineTextAlignment(.center)
+                .lineLimit(nil)
+                .minimumScaleFactor(0.8)
+
+            Text(alert.time)
+                .font(.caption2)
+                .foregroundColor(.tertiaryColor)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(
+            LinearGradient(
+                colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.tertiaryColor.opacity(0.2), lineWidth: 1)
+        )
+        .shadow(radius: 2)
+        .padding(.horizontal)
+    }
+}

--- a/NexStock1.0/View/AlertSectionView.swift
+++ b/NexStock1.0/View/AlertSectionView.swift
@@ -20,38 +20,7 @@ struct AlertSectionView: View {
                 .foregroundColor(.primary)
 
             ForEach(alerts) { alert in
-                VStack(spacing: 8) {
-                    Image(systemName: alert.icon)
-                        .foregroundColor(alert.severity.color)
-                        .font(.title2)
-
-                    Text(alert.message)
-                        .font(.subheadline)
-                        .foregroundColor(.tertiaryColor)
-                        .multilineTextAlignment(.center)
-                        .lineLimit(nil)
-                        .minimumScaleFactor(0.8)
-
-                    Text(alert.time)
-                        .font(.caption2)
-                        .foregroundColor(.tertiaryColor)
-                }
-                .padding()
-                .frame(maxWidth: .infinity)
-                .background(
-                    LinearGradient(
-                        colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-                .cornerRadius(10)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.tertiaryColor.opacity(0.2), lineWidth: 1)
-                )
-                .shadow(radius: 2)
-                .padding(.horizontal)
+                AlertCardView(alert: alert)
             }
         }
         .frame(maxWidth: .infinity)

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -33,36 +33,7 @@ struct AlertView: View {
                 ScrollView {
                     VStack(spacing: 12) {
                         ForEach(alerts) { alert in
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: alert.icon)
-                                    .foregroundColor(alert.severity.color)
-                                    .font(.system(size: 18))
-                                    .padding(.top, 2)
-
-                                VStack(alignment: .leading, spacing: 4) {
-                                    HStack {
-                                        Text(alert.sensor)
-                                            .fontWeight(.semibold)
-                                        Spacer()
-                                        Text(alert.time)
-                                            .foregroundColor(.gray)
-                                            .font(.caption)
-                                    }
-
-                                    Text(alert.message)
-                                        .font(.body)
-                                }
-                                .padding(12)
-                                .background(
-                                    LinearGradient(
-                                        colors: [alert.severity.color.opacity(0.2), Color.secondaryColor],
-                                        startPoint: .topLeading,
-                                        endPoint: .bottomTrailing
-                                    )
-                                )
-                                .cornerRadius(10)
-                            }
-                            .padding(.horizontal)
+                            AlertCardView(alert: alert)
                         }
                     }
                     .padding(.top, 10)


### PR DESCRIPTION
## Summary
- add `AlertCardView` for unified alert display
- reuse new component in `AlertSectionView` and `AlertView`

## Testing
- `swift --version`
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f56d12b3883278378301bf9e08088