### PR TITLE
Color alerts by sensor type

### DIFF
--- a/NexStock1.0/View/AlertCardView.swift
+++ b/NexStock1.0/View/AlertCardView.swift
@@ -5,13 +5,27 @@ struct AlertCardView: View {
     var title: String
     var message: String
     var date: String
+    var sensor: String
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
+
+    private var sensorColor: Color {
+        let lower = sensor.lowercased()
+        if lower.contains("vib") || lower.contains("mov") {
+            return .yellow
+        } else if lower.contains("gas") {
+            return .red
+        } else if lower.contains("hum") {
+            return .green
+        } else {
+            return .red
+        }
+    }
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
-                .foregroundColor(.red)
+                .foregroundColor(sensorColor)
                 .font(.system(size: 18))
                 .padding(.top, 2)
 
@@ -31,7 +45,7 @@ struct AlertCardView: View {
             .padding(12)
             .background(
                 LinearGradient(
-                    colors: [Color.red.opacity(0.2), Color.secondaryColor],
+                    colors: [sensorColor.opacity(0.2), Color.secondaryColor],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -42,7 +42,8 @@ struct AlertView: View {
                                     icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
-                                    date: formattedDate(alert.timestamp)
+                                    date: formattedDate(alert.timestamp),
+                                    sensor: alert.sensor
                                 )
                                 .padding(.horizontal)
                             }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -39,7 +39,8 @@ struct HomeView: View {
                                     icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
-                                    date: formattedDate(alert.timestamp)
+                                    date: formattedDate(alert.timestamp),
+                                    sensor: alert.sensor
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- vary gradient and icon color in `AlertCardView` depending on sensor type
- pass sensor info from `HomeView` and `AlertView` when building alert cards

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685f5d16cc648327bc505dcb4610a22f