### PR TITLE
Add colored alerts based on sensor

### DIFF
--- a/NexStock1.0/View/AlertCardView.swift
+++ b/NexStock1.0/View/AlertCardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AlertCardView: View {
+    var sensor: String
     var icon: String
     var title: String
     var message: String
@@ -8,35 +9,41 @@ struct AlertCardView: View {
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
+    /// Background color depends on the sensor type
+    private var backgroundColor: Color {
+        switch sensor.lowercased() {
+        case "gas":
+            return Color.red.opacity(0.2)
+        case "vibration":
+            return Color.yellow.opacity(0.2)
+        case "humidity":
+            return Color.green.opacity(0.2)
+        default:
+            return Color.gray.opacity(0.1)
+        }
+    }
+
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: icon)
-                .foregroundColor(.red)
-                .font(.system(size: 18))
-                .padding(.top, 2)
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(backgroundColor)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
+                    Image(systemName: icon)
+                        .foregroundColor(.primary)
                     Text(title)
-                        .fontWeight(.semibold)
-                    Spacer()
-                    Text(date)
-                        .foregroundColor(.gray)
-                        .font(.caption)
+                        .font(.headline)
                 }
 
                 Text(message)
-                    .font(.body)
+                    .font(.subheadline)
+
+                Text(date)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
-            .padding(12)
-            .background(
-                LinearGradient(
-                    colors: [Color.red.opacity(0.2), Color.secondaryColor],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .cornerRadius(10)
+            .padding()
         }
     }
 }

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -15,6 +15,19 @@ struct AlertView: View {
 
     @State private var allAlerts: [AlertNotification] = []
 
+    private func iconName(for sensor: String) -> String {
+        switch sensor.lowercased() {
+        case "gas":
+            return "flame.fill"
+        case "vibration":
+            return "waveform.path.ecg"
+        case "humidity":
+            return "drop.fill"
+        default:
+            return "questionmark.circle"
+        }
+    }
+
     var body: some View {
         ZStack(alignment: .leading) {
             Color.backColor.ignoresSafeArea()
@@ -39,7 +52,8 @@ struct AlertView: View {
 
                             ForEach(grouped[key] ?? []) { alert in
                                 AlertCardView(
-                                    icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
+                                    sensor: alert.sensor,
+                                    icon: iconName(for: alert.sensor),
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
                                     date: formattedDate(alert.timestamp)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -16,6 +16,19 @@ struct HomeView: View {
     @EnvironmentObject var theme: ThemeManager
 
 
+    private func iconName(for sensor: String) -> String {
+        switch sensor.lowercased() {
+        case "gas":
+            return "flame.fill"
+        case "vibration":
+            return "waveform.path.ecg"
+        case "humidity":
+            return "drop.fill"
+        default:
+            return "questionmark.circle"
+        }
+    }
+
     var body: some View {
         ZStack(alignment: .leading) {
             Color.backColor.ignoresSafeArea()
@@ -36,7 +49,8 @@ struct HomeView: View {
                         VStack(spacing: 12) {
                             ForEach(recentAlerts) { alert in
                                 AlertCardView(
-                                    icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
+                                    sensor: alert.sensor,
+                                    icon: iconName(for: alert.sensor),
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
                                     date: formattedDate(alert.timestamp)


### PR DESCRIPTION
## Summary
- adjust `AlertCardView` to color cards according to sensor type
- add helper to compute icons for sensors and pass sensor name
- update `HomeView` and `AlertView` to use new API

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f18ba308327898c664ee8e8409e