### PR TITLE
Add sensor based alert styling

### DIFF
--- a/NexStock1.0/View/AlertCardView.swift
+++ b/NexStock1.0/View/AlertCardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AlertCardView: View {
+    var sensor: String
     var icon: String
     var title: String
     var message: String
@@ -8,35 +9,40 @@ struct AlertCardView: View {
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
+    private var backgroundColor: Color {
+        switch sensor.lowercased() {
+        case "gas":
+            return Color.red.opacity(0.2)
+        case "vibration":
+            return Color.yellow.opacity(0.2)
+        case "humidity":
+            return Color.green.opacity(0.2)
+        default:
+            return Color.gray.opacity(0.1)
+        }
+    }
+
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: icon)
-                .foregroundColor(.red)
-                .font(.system(size: 18))
-                .padding(.top, 2)
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(backgroundColor)
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
+                    Image(systemName: icon)
+                        .foregroundColor(.primary)
                     Text(title)
-                        .fontWeight(.semibold)
-                    Spacer()
-                    Text(date)
-                        .foregroundColor(.gray)
-                        .font(.caption)
+                        .font(.headline)
                 }
 
                 Text(message)
-                    .font(.body)
+                    .font(.subheadline)
+
+                Text(date)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
             }
-            .padding(12)
-            .background(
-                LinearGradient(
-                    colors: [Color.red.opacity(0.2), Color.secondaryColor],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .cornerRadius(10)
+            .padding()
         }
     }
 }

--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -39,7 +39,8 @@ struct AlertView: View {
 
                             ForEach(grouped[key] ?? []) { alert in
                                 AlertCardView(
-                                    icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
+                                    sensor: alert.sensor,
+                                    icon: iconFor(sensor: alert.sensor),
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
                                     date: formattedDate(alert.timestamp)
@@ -64,6 +65,18 @@ struct AlertView: View {
             NotificationService.shared.fetchNotifications(limit: 50) { alerts in
                 self.allAlerts = alerts
             }
+        }
+
+    private func iconFor(sensor: String) -> String {
+        switch sensor.lowercased() {
+        case "gas":
+            return "flame.fill"
+        case "vibration":
+            return "waveform.path.ecg"
+        case "humidity":
+            return "drop.fill"
+        default:
+            return "exclamationmark.triangle"
         }
     }
 }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -36,7 +36,8 @@ struct HomeView: View {
                         VStack(spacing: 12) {
                             ForEach(recentAlerts) { alert in
                                 AlertCardView(
-                                    icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
+                                    sensor: alert.sensor,
+                                    icon: iconFor(sensor: alert.sensor),
                                     title: alert.sensor.uppercased(),
                                     message: alert.message,
                                     date: formattedDate(alert.timestamp)
@@ -98,6 +99,18 @@ struct HomeView: View {
             NotificationService.shared.fetchNotifications(limit: 6) { alerts in
                 self.recentAlerts = alerts
             }
+        }
+
+    private func iconFor(sensor: String) -> String {
+        switch sensor.lowercased() {
+        case "gas":
+            return "flame.fill"
+        case "vibration":
+            return "waveform.path.ecg"
+        case "humidity":
+            return "drop.fill"
+        default:
+            return "exclamationmark.triangle"
         }
     }
 }


### PR DESCRIPTION
## Summary
- color alerts based on the sensor type in `AlertCardView`
- use helper to pick alert icons in `HomeView`
- show proper icon and colored card in `AlertView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ffe4541a08327bdc5c6713b37cf5c