### PR TITLE
Remove movement card and sort alerts chronologically

### DIFF
--- a/NexStock1.0/View/AlertView.swift
+++ b/NexStock1.0/View/AlertView.swift
@@ -27,25 +27,23 @@ struct AlertView: View {
                     .padding(.horizontal)
 
                 ScrollView {
-                    let grouped = Dictionary(grouping: allAlerts) { alert in
-                        alert.sensor
+                    let sorted = allAlerts.sorted { a, b in
+                        if let d1 = ISO8601DateFormatter().date(from: a.timestamp),
+                           let d2 = ISO8601DateFormatter().date(from: b.timestamp) {
+                            return d1 > d2
+                        }
+                        return false
                     }
 
                     VStack(spacing: 12) {
-                        ForEach(grouped.keys.sorted(), id: \.self) { key in
-                            Text(key.uppercased())
-                                .font(.headline)
-                                .padding(.horizontal)
-
-                            ForEach(grouped[key] ?? []) { alert in
-                                AlertCardView(
-                                    icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
-                                    title: alert.sensor.uppercased(),
-                                    message: alert.message,
-                                    date: formattedDate(alert.timestamp)
-                                )
-                                .padding(.horizontal)
-                            }
+                        ForEach(sorted) { alert in
+                            AlertCardView(
+                                icon: alert.sensor == "Gas" ? "flame.fill" : "waveform.path.ecg",
+                                title: alert.sensor.uppercased(),
+                                message: alert.message,
+                                date: formattedDate(alert.timestamp)
+                            )
+                            .padding(.horizontal)
                         }
                     }
                     .padding(.top, 10)
@@ -62,7 +60,13 @@ struct AlertView: View {
         .navigationBarBackButtonHidden(true)
         .task {
             NotificationService.shared.fetchNotifications(limit: 50) { alerts in
-                self.allAlerts = alerts
+                self.allAlerts = alerts.sorted { a, b in
+                    if let d1 = ISO8601DateFormatter().date(from: a.timestamp),
+                       let d2 = ISO8601DateFormatter().date(from: b.timestamp) {
+                        return d1 > d2
+                    }
+                    return false
+                }
             }
         }
     }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -31,7 +31,6 @@ struct HomeView: View {
                         ])
 
                         SectionView(title: "monitoring".localized, cards: [
-                            CardModel(title: "Movimiento", subtitle: "hace 15 min.", icon: "figure.walk.motion"),
                             CardModel(
                                 title: "temperature".localized,
                                 subtitle: String(format: "%.1f °C", monitoringVM.temperature),
@@ -108,7 +107,13 @@ struct HomeView: View {
             summaryVM.fetchSummary()
             monitoringVM.fetch()
             NotificationService.shared.fetchNotifications(limit: 6) { alerts in
-                self.recentAlerts = alerts
+                self.recentAlerts = alerts.sorted { a, b in
+                    if let d1 = ISO8601DateFormatter().date(from: a.timestamp),
+                       let d2 = ISO8601DateFormatter().date(from: b.timestamp) {
+                        return d1 > d2
+                    }
+                    return false
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove movement card from HomeView
- order recent alerts by timestamp
- display all alerts sorted by date instead of grouping

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68600c535cb8832790b59e4bd621489e