### PR TITLE
Add inventory status views

### DIFF
--- a/NexStock1.0/Utils/NavigationRoutes.swift
+++ b/NexStock1.0/Utils/NavigationRoutes.swift
@@ -12,7 +12,13 @@ enum AppRoute: Hashable {
     case settings
     case userManagement
     case systemConfig
-    case product
+    case product // all products
+    case expiring
+    case outOfStock
+    case belowMinimum
+    case nearMinimum
+    case overstock
+    case shoppingList
     case temperature
     case humidity
     case alerts

--- a/NexStock1.0/View/AppView.swift
+++ b/NexStock1.0/View/AppView.swift
@@ -31,6 +31,18 @@ struct AppView: View {
                             path: $path,
                             showMenu: $showMenu
                         )
+                    case .expiring:
+                        InventoryStatusListView(title: "expiring", status: "expiring", path: $path)
+                    case .outOfStock:
+                        InventoryStatusListView(title: "out_of_stock", status: "out_of_stock", path: $path)
+                    case .belowMinimum:
+                        InventoryStatusListView(title: "below_minimum", status: "low_stock", path: $path)
+                    case .nearMinimum:
+                        InventoryStatusListView(title: "near_minimum", status: "near_minimum", path: $path)
+                    case .overstock:
+                        InventoryStatusListView(title: "overstock", status: "overstock", path: $path)
+                    case .shoppingList:
+                        InventoryStatusListView(title: "shopping_list", status: "shopping_list", path: $path)
                     case .userManagement:
                         UserManagementView()
                     case .systemConfig:

--- a/NexStock1.0/View/InventoryStatusListView.swift
+++ b/NexStock1.0/View/InventoryStatusListView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct InventoryStatusListView: View {
+    @Binding var path: NavigationPath
+    let title: String
+    let status: String?
+
+    @State private var showMenu = false
+    @StateObject private var viewModel: InventoryStatusViewModel
+    @State private var selectedProduct: ProductDetailInfo? = nil
+    @EnvironmentObject var localization: LocalizationManager
+    @EnvironmentObject var theme: ThemeManager
+
+    init(title: String, status: String?, path: Binding<NavigationPath>) {
+        self._path = path
+        self.title = title
+        self.status = status
+        _viewModel = StateObject(wrappedValue: InventoryStatusViewModel(status: status))
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Color.backColor.ignoresSafeArea()
+
+            VStack(spacing: 16) {
+                HeaderView(showMenu: $showMenu, path: $path)
+
+                Text(title.localized)
+                    .font(.title2.bold())
+                    .foregroundColor(.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 16) {
+                        ForEach(viewModel.products) { product in
+                            InventoryCardView(product: product) {
+                                openDetail(for: product)
+                            }
+                            .onAppear { viewModel.loadMoreIfNeeded(currentItem: product) }
+                        }
+                        if viewModel.isLoading {
+                            ProgressView()
+                                .padding()
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
+
+            if showMenu {
+                SideMenuView(isOpen: $showMenu, path: $path)
+                    .transition(.move(edge: .leading))
+                    .zIndex(1)
+            }
+        }
+        .animation(.easeInOut, value: showMenu)
+        .navigationBarBackButtonHidden(true)
+        .sheet(item: $selectedProduct) { product in
+            ProductDetailView(product: product)
+                .environmentObject(localization)
+        }
+        .onAppear { viewModel.fetchInitial() }
+    }
+
+    private func openDetail(for product: ProductModel) {
+        let idToUse = product.realId ?? product.id
+        ProductService.shared.fetchProductDetail(id: idToUse) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let detail):
+                    selectedProduct = detail
+                case .failure(let error):
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}

--- a/NexStock1.0/View/InventoryStatusListView.swift
+++ b/NexStock1.0/View/InventoryStatusListView.swift
@@ -32,7 +32,7 @@ struct InventoryStatusListView: View {
                     .padding(.horizontal)
 
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 16) {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
                         ForEach(viewModel.products) { product in
                             InventoryCardView(product: product) {
                                 openDetail(for: product)
@@ -42,6 +42,7 @@ struct InventoryStatusListView: View {
                         if viewModel.isLoading {
                             ProgressView()
                                 .padding()
+                                .frame(maxWidth: .infinity)
                         }
                     }
                     .padding(.horizontal)

--- a/NexStock1.0/View/SideMenuView.swift
+++ b/NexStock1.0/View/SideMenuView.swift
@@ -96,13 +96,12 @@ struct SideMenuView: View {
                             Button("all".localized) {
                                 path.append(AppRoute.product)
                             }
-
-                            Text("expiring".localized)
-                            Text("out_of_stock".localized)
-                            Text("below_minimum".localized)
-                            Text("near_minimum".localized)
-                            Text("overstock".localized)
-                            Text("shopping_list".localized)
+                            Button("expiring".localized) { path.append(AppRoute.expiring) }
+                            Button("out_of_stock".localized) { path.append(AppRoute.outOfStock) }
+                            Button("below_minimum".localized) { path.append(AppRoute.belowMinimum) }
+                            Button("near_minimum".localized) { path.append(AppRoute.nearMinimum) }
+                            Button("overstock".localized) { path.append(AppRoute.overstock) }
+                            Button("shopping_list".localized) { path.append(AppRoute.shoppingList) }
                         }
                         .font(.body)
                         .foregroundColor(.tertiaryColor)

--- a/NexStock1.0/ViewModels/InventoryStatusViewModel.swift
+++ b/NexStock1.0/ViewModels/InventoryStatusViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+class InventoryStatusViewModel: ObservableObject {
+    @Published var products: [ProductModel] = []
+    @Published var isLoading = false
+
+    private let status: String?
+    private var page = 1
+    private let limit = 10
+    private var reachedEnd = false
+
+    init(status: String?) {
+        self.status = status
+    }
+
+    func fetchInitial() {
+        page = 1
+        reachedEnd = false
+        products = []
+        fetchMore()
+    }
+
+    func loadMoreIfNeeded(currentItem: ProductModel) {
+        guard !isLoading, !reachedEnd, let last = products.last else { return }
+        if currentItem.id == last.id {
+            fetchMore()
+        }
+    }
+
+    private func fetchMore() {
+        isLoading = true
+        ProductService.shared.fetchInventoryProducts(status: status, page: page, limit: limit) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isLoading = false
+                switch result {
+                case .success(let newItems):
+                    if newItems.count < self.limit { self.reachedEnd = true } else { self.page += 1 }
+                    self.products.append(contentsOf: newItems)
+                case .failure(let error):
+                    print("Failed to load products for status \(self.status ?? "all"):", error)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add view model and screen for inventory status listings
- update service to fetch products by status
- wire up new views in navigation and side menu

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601eafc338832789fbd13060d4e5f2