### PR TITLE
Implement user edit and delete features

### DIFF
--- a/NexStock1.0/Models/UpdateUserModel.swift
+++ b/NexStock1.0/Models/UpdateUserModel.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct UpdateUserModel: Codable {
+    let username: String
+    let first_name: String
+    let last_name: String
+    let role_id: String
+}

--- a/NexStock1.0/Models/UserDetailsResponse.swift
+++ b/NexStock1.0/Models/UserDetailsResponse.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct UserDetail: Codable {
+    let id: String
+    let username: String
+    let first_name: String
+    let last_name: String
+    let role: RoleModel
+}
+
+struct UserDetailsResponse: Codable {
+    let user: UserDetail
+    let roles: [RoleModel]
+}

--- a/NexStock1.0/Models/UserTableModel.swift
+++ b/NexStock1.0/Models/UserTableModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct UserTableModel: Identifiable, Equatable {
-    let id = UUID()
+    let id: String
     let username: String
     let firstName: String
     let lastName: String

--- a/NexStock1.0/View/EditUserSheet.swift
+++ b/NexStock1.0/View/EditUserSheet.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct EditUserSheet: View {
+    let userId: String
+    var onSave: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var authService: AuthService
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    @State private var username = ""
+    @State private var firstName = ""
+    @State private var lastName = ""
+    @State private var selectedRole: RoleModel?
+    @State private var roles: [RoleModel] = []
+    @State private var showSuccessAlert = false
+    @State private var showErrorAlert = false
+
+    private var header: some View {
+        HStack {
+            Button(action: { dismiss() }) {
+                Image(systemName: "chevron.left")
+                    .font(.title2)
+                    .foregroundColor(.tertiaryColor)
+            }
+
+            Spacer()
+
+            Text("Editar usuario")
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+
+            Spacer()
+
+            Button("Guardar") { saveChanges() }
+                .disabled(username.isEmpty || firstName.isEmpty || lastName.isEmpty || selectedRole == nil)
+                .foregroundColor(.tertiaryColor)
+        }
+        .padding(.horizontal)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+        .background(Color.primaryColor)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                Color.primaryColor.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    header
+
+                    ScrollView {
+                        VStack(spacing: 20) {
+                            SectionContainer(title: "Información") {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Nombre de usuario")
+                                        .font(.caption)
+                                        .foregroundColor(.tertiaryColor)
+                                    TextField("Usuario", text: $username)
+                                        .padding(10)
+                                        .background(Color.fourthColor)
+                                        .cornerRadius(8)
+                                        .foregroundColor(.primary)
+                                }
+
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Nombre")
+                                        .font(.caption)
+                                        .foregroundColor(.tertiaryColor)
+                                    TextField("Nombre", text: $firstName)
+                                        .padding(10)
+                                        .background(Color.fourthColor)
+                                        .cornerRadius(8)
+                                        .foregroundColor(.primary)
+                                }
+
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Apellido")
+                                        .font(.caption)
+                                        .foregroundColor(.tertiaryColor)
+                                    TextField("Apellido", text: $lastName)
+                                        .padding(10)
+                                        .background(Color.fourthColor)
+                                        .cornerRadius(8)
+                                        .foregroundColor(.primary)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .foregroundColor(.tertiaryColor)
+
+                            SectionContainer(title: "Rol") {
+                                Picker("Rol", selection: $selectedRole) {
+                                    ForEach(roles, id: \.self) { role in
+                                        Text(role.name).tag(role as RoleModel?)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                            }
+                        }
+                        .padding()
+                        .foregroundColor(.tertiaryColor)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .onAppear { fetchDetails() }
+        .alert("Cambios guardados", isPresented: $showSuccessAlert) {
+            Button("OK", role: .cancel) {
+                dismiss()
+                onSave()
+            }
+        }
+        .alert("Ocurrió un error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) {}
+        }
+    }
+
+    private func fetchDetails() {
+        UserService.shared.fetchUserDetails(id: userId) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let response):
+                    let u = response.user
+                    username = u.username
+                    firstName = u.first_name
+                    lastName = u.last_name
+                    roles = response.roles
+                    selectedRole = response.roles.first(where: { $0.id == u.role.id })
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+    }
+
+    private func saveChanges() {
+        guard let role = selectedRole else { return }
+        let update = UpdateUserModel(username: username, first_name: firstName, last_name: lastName, role_id: role.id)
+        UserService.shared.updateUser(id: userId, user: update) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    showSuccessAlert = true
+                case .failure(let error):
+                    print(error)
+                    showErrorAlert = true
+                }
+            }
+        }
+    }
+}

--- a/NexStock1.0/View/UserManagementView.swift
+++ b/NexStock1.0/View/UserManagementView.swift
@@ -12,6 +12,10 @@ struct UserManagementView: View {
     @StateObject private var viewModel = UserManagementViewModel()
     @EnvironmentObject var authService: AuthService
     @State private var showAddUserSheet = false
+    @State private var editingUserId: String? = nil
+    @State private var showEditUserSheet = false
+    @State private var userToDelete: UserTableModel? = nil
+    @State private var showDeleteAlert = false
 
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.colorScheme) var colorScheme
@@ -71,7 +75,15 @@ struct UserManagementView: View {
                 ScrollView {
                     VStack(spacing: 16) {
                         ForEach(viewModel.users) { user in
-                            UserRowView(user: user)
+                            UserRowView(user: user,
+                                        onEdit: {
+                                            editingUserId = user.id
+                                            showEditUserSheet = true
+                                        },
+                                        onDelete: {
+                                            userToDelete = user
+                                            showDeleteAlert = true
+                                        })
                         }
                     }
                     .padding(.top)
@@ -93,12 +105,30 @@ struct UserManagementView: View {
             }
             .environmentObject(authService)
         }
+        .sheet(isPresented: $showEditUserSheet) {
+            if let id = editingUserId {
+                EditUserSheet(userId: id) {
+                    viewModel.fetchUsers()
+                }
+                .environmentObject(authService)
+            }
+        }
+        .alert("¿Eliminar usuario?", isPresented: $showDeleteAlert) {
+            Button("Cancelar", role: .cancel) {}
+            Button("Eliminar", role: .destructive) {
+                if let user = userToDelete {
+                    viewModel.deleteUser(id: user.id)
+                }
+            }
+        }
         .overlay(loadingOverlay)
     }
 }
 
 struct UserRowView: View {
     let user: UserTableModel
+    var onEdit: () -> Void
+    var onDelete: () -> Void
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
@@ -139,16 +169,12 @@ struct UserRowView: View {
                 .cornerRadius(8)
 
             HStack(spacing: 12) {
-                Button {
-                    print("Editar \(user.username)")
-                } label: {
+                Button(action: onEdit) {
                     Image(systemName: "square.and.pencil")
                         .foregroundColor(.accentColor)
                 }
 
-                Button {
-                    print("Eliminar \(user.username)")
-                } label: {
+                Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red)
                 }

--- a/NexStock1.0/ViewModels/UserManagementViewModel.swift
+++ b/NexStock1.0/ViewModels/UserManagementViewModel.swift
@@ -28,4 +28,17 @@ class UserManagementViewModel: ObservableObject {
             }
         }
     }
+
+    func deleteUser(id: String) {
+        UserService.shared.deleteUser(id: id) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self?.users.removeAll { $0.id == id }
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add models for editing users and decoding details
- extend `UserService` with methods to fetch, update and delete a user
- include backend id in `UserTableModel`
- create `EditUserSheet` to modify user fields
- hook edit and delete actions in `UserManagementView`
- support deleting a user via the view model

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609417ec68832781f7d5f8a9542a9b