### PR TITLE
Add password change modal in settings

### DIFF
--- a/NexStock1.0/Models/ChangePasswordModel.swift
+++ b/NexStock1.0/Models/ChangePasswordModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct ChangePasswordModel: Codable {
+    let new_password: String
+}

--- a/NexStock1.0/Services/AuthService.swift
+++ b/NexStock1.0/Services/AuthService.swift
@@ -21,9 +21,10 @@ enum AuthError: LocalizedError {
 
 class AuthService: ObservableObject {
     static let shared = AuthService()
-    
+
     @Published var token: String? = nil
     @Published var logoURL: String? = nil
+    @Published var userInfo: UserInfo? = nil
 
     var isAuthenticated: Bool {
         return token != nil
@@ -68,6 +69,7 @@ class AuthService: ObservableObject {
                 DispatchQueue.main.async {
                     self.token = decoded.accessToken
                     self.logoURL = decoded.settings.logo_url
+                    self.userInfo = decoded.user
                     if let p = Color(hex: decoded.settings.color_primary) {
                         ThemeManager.shared.primaryColor = p
                     }
@@ -91,6 +93,7 @@ class AuthService: ObservableObject {
 
     func logout() {
         token = nil
+        userInfo = nil
         UserDefaults.standard.removeObject(forKey: "authToken")
     }
 }

--- a/NexStock1.0/Services/UserService.swift
+++ b/NexStock1.0/Services/UserService.swift
@@ -292,6 +292,47 @@ extension UserService {
         }.resume()
     }
 
+    func changePassword(id: String, newPassword: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let token = AuthService.shared.token else {
+            completion(.failure(NSError(domain: "UserService", code: 401, userInfo: [NSLocalizedDescriptionKey: "No token disponible."])))
+            return
+        }
+        guard let url = URL(string: "\(baseURL)/auth/users/\(id)/password") else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let payload = ChangePasswordModel(new_password: newPassword)
+        do {
+            request.httpBody = try JSONEncoder().encode(payload)
+        } catch {
+            completion(.failure(error))
+            return
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let http = response as? HTTPURLResponse, let data = data else {
+                completion(.failure(NSError(domain: "UserService", code: 0, userInfo: nil)))
+                return
+            }
+            print("[UserService] changePassword statusCode: \(http.statusCode)")
+            if let body = String(data: data, encoding: .utf8) { print("[UserService] changePassword body:\n\(body)") }
+            if http.statusCode != 200 {
+                if let msg = try? JSONDecoder().decode([String: String].self, from: data)["message"] {
+                    completion(.failure(NSError(domain: "UserService", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: msg])))
+                } else {
+                    completion(.failure(NSError(domain: "UserService", code: http.statusCode, userInfo: nil)))
+                }
+                return
+            }
+            completion(.success(()))
+        }.resume()
+    }
+
     func deleteUser(id: String, completion: @escaping (Result<Void, Error>) -> Void) {
         guard let token = AuthService.shared.token else {
             completion(.failure(NSError(domain: "UserService", code: 401, userInfo: [NSLocalizedDescriptionKey: "No token disponible."])))

--- a/NexStock1.0/View/ChangePasswordSheet.swift
+++ b/NexStock1.0/View/ChangePasswordSheet.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct ChangePasswordSheet: View {
+    @State private var newPassword = ""
+    @State private var showSuccessAlert = false
+    @State private var showErrorAlert = false
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var authService: AuthService
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    private var header: some View {
+        HStack {
+            Button(action: { dismiss() }) {
+                Image(systemName: "chevron.left")
+                    .font(.title2)
+                    .foregroundColor(.tertiaryColor)
+            }
+
+            Spacer()
+
+            Text("change_password".localized)
+                .font(.headline)
+                .foregroundColor(.tertiaryColor)
+
+            Spacer()
+
+            Button("Guardar") { changePassword() }
+                .disabled(newPassword.isEmpty)
+                .foregroundColor(.tertiaryColor)
+        }
+        .padding(.horizontal)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+        .background(Color.primaryColor)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                Color.primaryColor.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    header
+
+                    ScrollView {
+                        VStack(spacing: 20) {
+                            SectionContainer(title: "") {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Nueva contraseña")
+                                        .font(.caption)
+                                        .foregroundColor(.tertiaryColor)
+                                    SecureField("Nueva contraseña", text: $newPassword)
+                                        .padding(10)
+                                        .background(Color.fourthColor)
+                                        .cornerRadius(8)
+                                        .foregroundColor(.primary)
+                                }
+                            }
+                        }
+                        .padding()
+                        .foregroundColor(.tertiaryColor)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .alert("Contraseña actualizada correctamente", isPresented: $showSuccessAlert) {
+            Button("OK", role: .cancel) {
+                dismiss()
+            }
+        }
+        .alert("Ocurrió un error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) {}
+        }
+    }
+
+    private func changePassword() {
+        guard let id = authService.userInfo?.id else {
+            showErrorAlert = true
+            return
+        }
+        UserService.shared.changePassword(id: id, newPassword: newPassword) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    showSuccessAlert = true
+                case .failure(let error):
+                    print(error)
+                    showErrorAlert = true
+                }
+            }
+        }
+    }
+}

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
     @EnvironmentObject var theme: ThemeManager
     @State private var notificationsEnabled = true
     @State private var userRole: UserRole = .admin
+    @State private var showChangePassword = false
     @Environment(\.presentationMode) var presentationMode
     @Binding var path: NavigationPath
 
@@ -56,6 +57,7 @@ struct SettingsView: View {
                             SettingRow(icon: "person.fill", title: "username".localized, subtitle: "Jose Rodriguez")
                             SettingRow(icon: "envelope.fill", title: "email".localized, subtitle: "jose@email.com")
                             SettingRow(icon: "key.fill", title: "change_password".localized)
+                                .onTapGesture { showChangePassword = true }
                         }
 
                         // ⚙️ Preferencias
@@ -147,6 +149,9 @@ struct SettingsView: View {
             applyAppearance()
         }
         .onAppear { applyAppearance() }
+        .sheet(isPresented: $showChangePassword) {
+            ChangePasswordSheet()
+        }
         .navigationBarBackButtonHidden(true)
     }
 


### PR DESCRIPTION
## Summary
- store logged-in user information
- allow changing password with new `ChangePasswordSheet`
- add `ChangePasswordModel` and service call
- trigger password modal from `SettingsView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6860a18207a48327bb41ec158f55be4a