### PR TITLE
Apply user language and theme after login

### DIFF
--- a/NexStock1.0/Evironment/LocalizationManager.swift
+++ b/NexStock1.0/Evironment/LocalizationManager.swift
@@ -18,6 +18,10 @@ class LocalizationManager: ObservableObject {
         }
     }
 
+    func setLanguage(_ language: String) {
+        selectedLanguage = language
+    }
+
     func localizedString(forKey key: String) -> String {
         let language = selectedLanguage
         guard let path = Bundle.main.path(forResource: language, ofType: "json"),

--- a/NexStock1.0/Utils/ThemeManager.swift
+++ b/NexStock1.0/Utils/ThemeManager.swift
@@ -3,7 +3,26 @@ import SwiftUI
 class ThemeManager: ObservableObject {
     static let shared = ThemeManager()
 
+    @AppStorage("selectedAppearance") var selectedAppearance: String = "system" {
+        didSet { applyAppearance() }
+    }
+
     @Published var primaryColor: Color = Color("appPrimaryColor")
     @Published var secondaryColor: Color = Color("appSecondaryColor")
     @Published var tertiaryColor: Color = Color("appTertiaryColor")
+
+    func setTheme(_ theme: String) {
+        selectedAppearance = theme
+    }
+
+    private func applyAppearance() {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ ($0 as? UIWindowScene)?.keyWindow }).first else { return }
+
+        switch selectedAppearance {
+        case "light": window.overrideUserInterfaceStyle = .light
+        case "dark": window.overrideUserInterfaceStyle = .dark
+        default: window.overrideUserInterfaceStyle = .unspecified
+        }
+    }
 }

--- a/NexStock1.0/ViewModels/LoginViewModel.swift
+++ b/NexStock1.0/ViewModels/LoginViewModel.swift
@@ -31,6 +31,20 @@ class LoginViewModel: ObservableObject {
                     self?.isLoggedIn = true
                     // Obtener configuraci\u00f3n del sistema al iniciar sesi\u00f3n
                     SystemConfigViewModel().fetchConfig()
+                    // Preferencias de usuario
+                    UserService.shared.fetchPreferences(id: response.user.id) { prefsResult in
+                        DispatchQueue.main.async {
+                            switch prefsResult {
+                            case .success(let prefs):
+                                LocalizationManager.shared.setLanguage(prefs.language)
+                                ThemeManager.shared.setTheme(prefs.theme)
+                            case .failure(let error):
+                                print(error.localizedDescription)
+                                LocalizationManager.shared.setLanguage("es")
+                                ThemeManager.shared.setTheme("light")
+                            }
+                        }
+                    }
                     completion(true)
                 case .failure(let error):
                     self?.errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- implement `setLanguage` helper in `LocalizationManager`
- manage color appearance in `ThemeManager`
- add user preference request in `UserService`
- fetch and apply preferences when logging in

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6860a55c8ec88327acb477966f101261