### PR TITLE
Enhance search bar focus visuals

### DIFF
--- a/NexStock1.0/View/InventoryScreenView.swift
+++ b/NexStock1.0/View/InventoryScreenView.swift
@@ -28,15 +28,8 @@ struct InventoryScreenView: View {
             content
         }
         .overlay(addButton, alignment: .bottomTrailing)
-        .overlay(
-            Group {
-                if isSearchFocused {
-                    Color.black.opacity(0.3)
-                        .ignoresSafeArea()
-                        .onTapGesture { isSearchFocused = false }
-                }
-            }
-        )
+        // Removed dimming overlay when search bar is focused so that only the
+        // search bar highlights without darkening the rest of the screen
         .sheet(isPresented: $showAddProductSheet) {
             AddProductSheet { _ in
                 showAddProductSheet = false
@@ -76,6 +69,10 @@ struct InventoryScreenView: View {
         .padding()
         .background(isSearchFocused ? Color.tertiaryColor : Color.secondaryColor)
         .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.primaryColor.opacity(isSearchFocused ? 0.8 : 0), lineWidth: 2)
+        )
         .shadow(radius: isSearchFocused ? 8 : 0)
         .padding(.horizontal)
         .onChange(of: searchVM.query) { text in


### PR DESCRIPTION
## Summary
- stop dimming the entire screen when the search bar is focused
- add a highlight stroke to the search bar while focused

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686172b9864c832797eaa7665bdf0d4a