### PR TITLE
Enable navigation from home

### DIFF
--- a/NexStock1.0/Resources/de.json
+++ b/NexStock1.0/Resources/de.json
@@ -96,5 +96,6 @@
   "close": "Schließen",
   "no_information": "Keine Information",
   "before": "Vorher",
-  "after": "Nachher"
+  "after": "Nachher",
+  "see_more": "Mehr anzeigen"
 }

--- a/NexStock1.0/Resources/en.json
+++ b/NexStock1.0/Resources/en.json
@@ -101,5 +101,6 @@
   "close": "Close",
   "no_information": "No information",
   "before": "Before",
-  "after": "After"
+  "after": "After",
+  "see_more": "See more"
 }

--- a/NexStock1.0/Resources/es.json
+++ b/NexStock1.0/Resources/es.json
@@ -97,5 +97,6 @@
   "close": "Cerrar",
   "no_information": "Sin información",
   "before": "Antes",
-  "after": "Después"
+  "after": "Después",
+  "see_more": "Ver más"
 }

--- a/NexStock1.0/Resources/fr.json
+++ b/NexStock1.0/Resources/fr.json
@@ -98,5 +98,6 @@
   "close": "Fermer",
   "no_information": "Pas d'information",
   "before": "Avant",
-  "after": "Après"
+  "after": "Après",
+  "see_more": "Voir plus"
 }

--- a/NexStock1.0/Resources/it.json
+++ b/NexStock1.0/Resources/it.json
@@ -96,5 +96,6 @@
   "close": "Chiudi",
   "no_information": "Nessuna informazione",
   "before": "Prima",
-  "after": "Dopo"
+  "after": "Dopo",
+  "see_more": "Vedi di più"
 }

--- a/NexStock1.0/Resources/ja.json
+++ b/NexStock1.0/Resources/ja.json
@@ -96,5 +96,6 @@
   "close": "閉じる",
   "no_information": "情報なし",
   "before": "前",
-  "after": "後"
+  "after": "後",
+  "see_more": "もっと見る"
 }

--- a/NexStock1.0/Resources/zh.json
+++ b/NexStock1.0/Resources/zh.json
@@ -96,5 +96,6 @@
   "close": "关闭",
   "no_information": "没有信息",
   "before": "之前",
-  "after": "之后"
+  "after": "之后",
+  "see_more": "查看更多"
 }

--- a/NexStock1.0/Services/AuthService.swift
+++ b/NexStock1.0/Services/AuthService.swift
@@ -25,6 +25,7 @@ class AuthService: ObservableObject {
     @Published var token: String? = nil
     @Published var logoURL: String? = nil
     @Published var userInfo: UserInfo? = nil
+    @Published var showWelcome = false
 
     var isAuthenticated: Bool {
         return token != nil
@@ -80,6 +81,8 @@ class AuthService: ObservableObject {
                         ThemeManager.shared.tertiaryColor = t
                     }
 
+                    self.showWelcome = true
+
                     // Call completion after token is available
                     completion(.success(decoded))
                 }
@@ -95,6 +98,7 @@ class AuthService: ObservableObject {
     func logout() {
         token = nil
         userInfo = nil
+        showWelcome = false
         UserDefaults.standard.removeObject(forKey: "authToken")
     }
 }

--- a/NexStock1.0/View/HeaderView.swift
+++ b/NexStock1.0/View/HeaderView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct HeaderView: View {
     @Binding var showMenu: Bool
     @Binding var path: NavigationPath
-    @State private var showUsername = true
+    @State private var showUsername = false
     @Environment(\.sizeCategory) var sizeCategory
     @EnvironmentObject var localization: LocalizationManager
     @EnvironmentObject var authService: AuthService
@@ -85,9 +85,13 @@ struct HeaderView: View {
         .padding(.bottom, 6)
         .background(Color.primaryColor)
         .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                withAnimation {
-                    showUsername = false
+            showUsername = authService.showWelcome
+            if showUsername {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    withAnimation {
+                        showUsername = false
+                        authService.showWelcome = false
+                    }
                 }
             }
         }

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -3,16 +3,27 @@ import SwiftUI
 struct HomeSummarySectionView: View {
     let title: String
     let products: [ProductModel]
+    var onSeeAll: (() -> Void)? = nil
 
     @EnvironmentObject var theme: ThemeManager
     @EnvironmentObject var localization: LocalizationManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.title3.bold())
-                .foregroundColor(.primary)
-                .padding(.horizontal)
+            HStack {
+                Text(title)
+                    .font(.title3.bold())
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                if let onSeeAll = onSeeAll {
+                    Button("see_more".localized) { onSeeAll() }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                }
+            }
+            .padding(.horizontal)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {

--- a/NexStock1.0/View/HomeSummarySectionView.swift
+++ b/NexStock1.0/View/HomeSummarySectionView.swift
@@ -18,9 +18,7 @@ struct HomeSummarySectionView: View {
                 Spacer()
 
                 if let onSeeAll = onSeeAll {
-                    Button("see_more".localized) { onSeeAll() }
-                        .font(.caption)
-                        .foregroundColor(.blue)
+                    SeeMoreButton(label: "see_more".localized) { onSeeAll() }
                 }
             }
             .padding(.horizontal)

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -30,18 +30,48 @@ struct HomeView: View {
                             CardModel(title: "Utilidad", subtitle: "$7,584.00")
                         ])
 
-                        SectionView(title: "monitoring".localized, cards: [
-                            CardModel(
-                                title: "temperature".localized,
-                                subtitle: String(format: "%.1f °C", monitoringVM.temperature),
-                                icon: "thermometer"
-                            ),
-                            CardModel(
-                                title: "humidity".localized,
-                                subtitle: String(format: "%.0f %%", monitoringVM.humidity),
-                                icon: "drop.fill"
-                            )
-                        ])
+                        VStack(alignment: .center, spacing: 10) {
+                            Text("monitoring".localized)
+                                .font(.title2)
+                                .fontWeight(.bold)
+                                .foregroundColor(.primary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 20) {
+                                    Button(action: { path.append(AppRoute.temperature) }) {
+                                        CardView(model: CardModel(
+                                            title: "temperature".localized,
+                                            subtitle: String(format: "%.1f °C", monitoringVM.temperature),
+                                            icon: "thermometer"
+                                        ))
+                                    }
+                                    Button(action: { path.append(AppRoute.humidity) }) {
+                                        CardView(model: CardModel(
+                                            title: "humidity".localized,
+                                            subtitle: String(format: "%.0f %%", monitoringVM.humidity),
+                                            icon: "drop.fill"
+                                        ))
+                                    }
+                                }
+                                .padding(.horizontal)
+                            }
+                        }
+
+                        HStack {
+                            Text("alerts".localized)
+                                .font(.title3.bold())
+                                .foregroundColor(.primary)
+
+                            Spacer()
+
+                            Button("see_more".localized) {
+                                path.append(AppRoute.alerts)
+                            }
+                            .font(.caption)
+                            .foregroundColor(.blue)
+                        }
+                        .padding(.horizontal)
 
                         VStack(spacing: 12) {
                             ForEach(recentAlerts) { alert in
@@ -59,35 +89,40 @@ struct HomeView: View {
                             if let items = summary.expiring, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "expiring".localized,
-                                    products: items.map { ProductModel(from: $0) }
+                                    products: items.map { ProductModel(from: $0) },
+                                    onSeeAll: { path.append(AppRoute.expiring) }
                                 )
                             }
 
                             if let items = summary.out_of_stock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "out_of_stock".localized,
-                                    products: items.map { ProductModel(from: $0) }
+                                    products: items.map { ProductModel(from: $0) },
+                                    onSeeAll: { path.append(AppRoute.outOfStock) }
                                 )
                             }
 
                             if let items = summary.low_stock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "below_minimum".localized,
-                                    products: items.map { ProductModel(from: $0) }
+                                    products: items.map { ProductModel(from: $0) },
+                                    onSeeAll: { path.append(AppRoute.belowMinimum) }
                                 )
                             }
 
                             if let items = summary.near_minimum, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "near_minimum".localized,
-                                    products: items.map { ProductModel(from: $0) }
+                                    products: items.map { ProductModel(from: $0) },
+                                    onSeeAll: { path.append(AppRoute.nearMinimum) }
                                 )
                             }
 
                             if let items = summary.overstock, !items.isEmpty {
                                 HomeSummarySectionView(
                                     title: "overstock".localized,
-                                    products: items.map { ProductModel(from: $0) }
+                                    products: items.map { ProductModel(from: $0) },
+                                    onSeeAll: { path.append(AppRoute.overstock) }
                                 )
                             }
                         }

--- a/NexStock1.0/View/HomeView.swift
+++ b/NexStock1.0/View/HomeView.swift
@@ -65,11 +65,9 @@ struct HomeView: View {
 
                             Spacer()
 
-                            Button("see_more".localized) {
+                            SeeMoreButton(label: "see_more".localized) {
                                 path.append(AppRoute.alerts)
                             }
-                            .font(.caption)
-                            .foregroundColor(.blue)
                         }
                         .padding(.horizontal)
 

--- a/NexStock1.0/View/SeeMoreButton.swift
+++ b/NexStock1.0/View/SeeMoreButton.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct SeeMoreButton: View {
+    var label: String
+    var action: () -> Void
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Text(label)
+                Image(systemName: "chevron.right")
+            }
+            .font(.caption.bold())
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .background(Color.secondaryColor)
+            .foregroundColor(.tertiaryColor)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(Color.tertiaryColor.opacity(0.5), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    SeeMoreButton(label: "See more") {}
+        .environmentObject(ThemeManager.shared)
+        .environmentObject(LocalizationManager.shared)
+}


### PR DESCRIPTION
## Summary
- connect Temperature and Humidity cards on the home screen to their views
- show alert section header with a "See more" button
- allow inventory summary sections to navigate to their full lists
- expose optional See More button in `HomeSummarySectionView`
- add `see_more` translation to all languages

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project NexStock1.0.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617e154a7c832797b2e0b0a0b7b2c4