### PR TITLE
Modify settings options to use custom buttons

### DIFF
--- a/NexStock1.0/View/ExpandButton.swift
+++ b/NexStock1.0/View/ExpandButton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ExpandButton: View {
+    var label: String
+    var isExpanded: Bool
+    var action: () -> Void
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Text(label)
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+            }
+            .font(.caption.bold())
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .background(
+                LinearGradient(
+                    colors: [Color.secondaryColor, Color.primaryColor.opacity(0.7)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .foregroundColor(.tertiaryColor)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(Color.tertiaryColor.opacity(0.4), lineWidth: 1)
+            )
+            .shadow(color: Color.primaryColor.opacity(0.2), radius: 2, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    ExpandButton(label: "Languages", isExpanded: false) {}
+        .environmentObject(ThemeManager.shared)
+        .environmentObject(LocalizationManager.shared)
+}

--- a/NexStock1.0/View/OptionButton.swift
+++ b/NexStock1.0/View/OptionButton.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct OptionButton: View {
+    var label: String
+    var isSelected: Bool
+    var action: () -> Void
+    @EnvironmentObject var theme: ThemeManager
+    @EnvironmentObject var localization: LocalizationManager
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.bold())
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .background(isSelected ? Color.tertiaryColor : Color.secondaryColor)
+                .foregroundColor(isSelected ? Color.secondaryColor : Color.tertiaryColor)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(Color.tertiaryColor.opacity(0.5), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    OptionButton(label: "Option", isSelected: true) {}
+        .environmentObject(ThemeManager.shared)
+        .environmentObject(LocalizationManager.shared)
+}

--- a/NexStock1.0/View/OptionButton.swift
+++ b/NexStock1.0/View/OptionButton.swift
@@ -10,9 +10,9 @@ struct OptionButton: View {
     var body: some View {
         Button(action: action) {
             Text(label)
-                .font(.caption.bold())
-                .padding(.vertical, 6)
-                .padding(.horizontal, 10)
+                .font(.footnote.weight(.semibold))
+                .padding(.vertical, 8)
+                .padding(.horizontal, 12)
                 .background(isSelected ? Color.tertiaryColor : Color.secondaryColor)
                 .foregroundColor(isSelected ? Color.secondaryColor : Color.tertiaryColor)
                 .clipShape(Capsule())

--- a/NexStock1.0/View/OptionButton.swift
+++ b/NexStock1.0/View/OptionButton.swift
@@ -11,15 +11,22 @@ struct OptionButton: View {
         Button(action: action) {
             Text(label)
                 .font(.footnote.weight(.semibold))
-                .padding(.vertical, 8)
-                .padding(.horizontal, 12)
-                .background(isSelected ? Color.tertiaryColor : Color.secondaryColor)
+                .padding(.vertical, 10)
+                .padding(.horizontal, 14)
+                .background(
+                    LinearGradient(
+                        colors: isSelected ? [Color.tertiaryColor, Color.primaryColor] : [Color.secondaryColor, Color.primaryColor.opacity(0.7)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
                 .foregroundColor(isSelected ? Color.secondaryColor : Color.tertiaryColor)
                 .clipShape(Capsule())
                 .overlay(
                     Capsule()
-                        .stroke(Color.tertiaryColor.opacity(0.5), lineWidth: 1)
+                        .stroke(Color.tertiaryColor.opacity(0.4), lineWidth: 1)
                 )
+                .shadow(color: Color.primaryColor.opacity(0.2), radius: 2, x: 0, y: 1)
         }
         .buttonStyle(.plain)
     }

--- a/NexStock1.0/View/SeeMoreButton.swift
+++ b/NexStock1.0/View/SeeMoreButton.swift
@@ -13,15 +13,22 @@ struct SeeMoreButton: View {
                 Image(systemName: "chevron.right")
             }
             .font(.caption.bold())
-            .padding(.vertical, 6)
-            .padding(.horizontal, 10)
-            .background(Color.secondaryColor)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .background(
+                LinearGradient(
+                    colors: [Color.secondaryColor, Color.primaryColor.opacity(0.7)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
             .foregroundColor(.tertiaryColor)
             .clipShape(Capsule())
             .overlay(
                 Capsule()
-                    .stroke(Color.tertiaryColor.opacity(0.5), lineWidth: 1)
+                    .stroke(Color.tertiaryColor.opacity(0.4), lineWidth: 1)
             )
+            .shadow(color: Color.primaryColor.opacity(0.2), radius: 2, x: 0, y: 1)
         }
         .buttonStyle(.plain)
     }

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -74,12 +74,17 @@ struct SettingsView: View {
                                         .font(.body)
                                         .foregroundColor(.fourthColor)
 
-                                    Picker("Apariencia", selection: $selectedAppearance) {
-                                        Text("light".localized).tag("light")
-                                        Text("dark".localized).tag("dark")
-                                        Text("automatic".localized).tag("system")
+                                    OptionButton(label: "light".localized, isSelected: selectedAppearance == "light") {
+                                        selectedAppearance = "light"
                                     }
-                                    .pickerStyle(MenuPickerStyle())
+
+                                    OptionButton(label: "dark".localized, isSelected: selectedAppearance == "dark") {
+                                        selectedAppearance = "dark"
+                                    }
+
+                                    OptionButton(label: "automatic".localized, isSelected: selectedAppearance == "system") {
+                                        selectedAppearance = "system"
+                                    }
 
                                     Spacer()
                                 }
@@ -94,16 +99,33 @@ struct SettingsView: View {
                                         .font(.body)
                                         .foregroundColor(.fourthColor)
 
-                                    Picker("Idioma", selection: $selectedLanguage) {
-                                        Text("Español 🇲🇽").tag("es")
-                                        Text("English 🇺🇸").tag("en")
-                                        Text("Français 🇫🇷").tag("fr")
-                                        Text("Deutsch 🇩🇪").tag("de")
-                                        Text("Italiano 🇮🇹").tag("it")
-                                        Text("日本語 🇯🇵").tag("ja")
-                                        Text("中文 🇨🇳").tag("zh")
+                                    OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
+                                        selectedLanguage = "es"
                                     }
-                                    .pickerStyle(MenuPickerStyle())
+
+                                    OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
+                                        selectedLanguage = "en"
+                                    }
+
+                                    OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
+                                        selectedLanguage = "fr"
+                                    }
+
+                                    OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
+                                        selectedLanguage = "de"
+                                    }
+
+                                    OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
+                                        selectedLanguage = "it"
+                                    }
+
+                                    OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
+                                        selectedLanguage = "ja"
+                                    }
+
+                                    OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
+                                        selectedLanguage = "zh"
+                                    }
 
                                     Spacer()
                                 }

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -65,66 +65,74 @@ struct SettingsView: View {
                             VStack(alignment: .leading, spacing: 12) {
 
                                 // 🎨 Apariencia
-                                HStack(alignment: .center, spacing: 12) {
+                                HStack(alignment: .top, spacing: 12) {
                                     Image(systemName: "paintbrush.fill")
                                         .foregroundColor(.fourthColor)
                                         .font(.body)
 
-                                    Text("appearance".localized)
-                                        .font(.body)
-                                        .foregroundColor(.fourthColor)
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("appearance".localized)
+                                            .font(.body)
+                                            .foregroundColor(.fourthColor)
 
-                                    OptionButton(label: "light".localized, isSelected: selectedAppearance == "light") {
-                                        selectedAppearance = "light"
-                                    }
+                                        HStack(spacing: 8) {
+                                            OptionButton(label: "light".localized, isSelected: selectedAppearance == "light") {
+                                                selectedAppearance = "light"
+                                            }
 
-                                    OptionButton(label: "dark".localized, isSelected: selectedAppearance == "dark") {
-                                        selectedAppearance = "dark"
-                                    }
+                                            OptionButton(label: "dark".localized, isSelected: selectedAppearance == "dark") {
+                                                selectedAppearance = "dark"
+                                            }
 
-                                    OptionButton(label: "automatic".localized, isSelected: selectedAppearance == "system") {
-                                        selectedAppearance = "system"
+                                            OptionButton(label: "automatic".localized, isSelected: selectedAppearance == "system") {
+                                                selectedAppearance = "system"
+                                            }
+                                        }
                                     }
 
                                     Spacer()
                                 }
 
                                 // 🌐 Idioma
-                                HStack(alignment: .center, spacing: 12) {
+                                HStack(alignment: .top, spacing: 12) {
                                     Image(systemName: "globe")
                                         .foregroundColor(.fourthColor)
                                         .font(.body)
 
-                                    Text("languages")
-                                        .font(.body)
-                                        .foregroundColor(.fourthColor)
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("languages")
+                                            .font(.body)
+                                            .foregroundColor(.fourthColor)
 
-                                    OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
-                                        selectedLanguage = "es"
-                                    }
+                                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: 8) {
+                                            OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
+                                                selectedLanguage = "es"
+                                            }
 
-                                    OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
-                                        selectedLanguage = "en"
-                                    }
+                                            OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
+                                                selectedLanguage = "en"
+                                            }
 
-                                    OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
-                                        selectedLanguage = "fr"
-                                    }
+                                            OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
+                                                selectedLanguage = "fr"
+                                            }
 
-                                    OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
-                                        selectedLanguage = "de"
-                                    }
+                                            OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
+                                                selectedLanguage = "de"
+                                            }
 
-                                    OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
-                                        selectedLanguage = "it"
-                                    }
+                                            OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
+                                                selectedLanguage = "it"
+                                            }
 
-                                    OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
-                                        selectedLanguage = "ja"
-                                    }
+                                            OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
+                                                selectedLanguage = "ja"
+                                            }
 
-                                    OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
-                                        selectedLanguage = "zh"
+                                            OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
+                                                selectedLanguage = "zh"
+                                            }
+                                        }
                                     }
 
                                     Spacer()

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @State private var notificationsEnabled = true
     @State private var userRole: UserRole = .admin
     @State private var showChangePassword = false
+    @State private var languagesExpanded = false
     @Environment(\.presentationMode) var presentationMode
     @Binding var path: NavigationPath
 
@@ -100,39 +101,45 @@ struct SettingsView: View {
                                         .font(.body)
 
                                     VStack(alignment: .leading, spacing: 8) {
-                                        Text("languages")
-                                            .font(.body)
-                                            .foregroundColor(.fourthColor)
+                                        DisclosureGroup(
+                                            isExpanded: $languagesExpanded,
+                                            content: {
+                                                VStack(alignment: .leading, spacing: 8) {
+                                                    OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
+                                                        selectedLanguage = "es"
+                                                    }
 
-                                        VStack(alignment: .leading, spacing: 8) {
-                                            OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
-                                                selectedLanguage = "es"
-                                            }
+                                                    OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
+                                                        selectedLanguage = "en"
+                                                    }
 
-                                            OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
-                                                selectedLanguage = "en"
-                                            }
+                                                    OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
+                                                        selectedLanguage = "fr"
+                                                    }
 
-                                            OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
-                                                selectedLanguage = "fr"
-                                            }
+                                                    OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
+                                                        selectedLanguage = "de"
+                                                    }
 
-                                            OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
-                                                selectedLanguage = "de"
-                                            }
+                                                    OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
+                                                        selectedLanguage = "it"
+                                                    }
 
-                                            OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
-                                                selectedLanguage = "it"
-                                            }
+                                                    OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
+                                                        selectedLanguage = "ja"
+                                                    }
 
-                                            OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
-                                                selectedLanguage = "ja"
+                                                    OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
+                                                        selectedLanguage = "zh"
+                                                    }
+                                                }
+                                            },
+                                            label: {
+                                                Text("languages")
+                                                    .font(.body)
+                                                    .foregroundColor(.fourthColor)
                                             }
-
-                                            OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
-                                                selectedLanguage = "zh"
-                                            }
-                                        }
+                                        )
                                     }
 
                                     Spacer()

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -101,45 +101,42 @@ struct SettingsView: View {
                                         .font(.body)
 
                                     VStack(alignment: .leading, spacing: 8) {
-                                        DisclosureGroup(
-                                            isExpanded: $languagesExpanded,
-                                            content: {
-                                                VStack(alignment: .leading, spacing: 8) {
-                                                    OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
-                                                        selectedLanguage = "es"
-                                                    }
+                                        ExpandButton(label: "languages".localized,
+                                                     isExpanded: languagesExpanded) {
+                                            withAnimation { languagesExpanded.toggle() }
+                                        }
 
-                                                    OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
-                                                        selectedLanguage = "en"
-                                                    }
-
-                                                    OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
-                                                        selectedLanguage = "fr"
-                                                    }
-
-                                                    OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
-                                                        selectedLanguage = "de"
-                                                    }
-
-                                                    OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
-                                                        selectedLanguage = "it"
-                                                    }
-
-                                                    OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
-                                                        selectedLanguage = "ja"
-                                                    }
-
-                                                    OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
-                                                        selectedLanguage = "zh"
-                                                    }
+                                        if languagesExpanded {
+                                            VStack(alignment: .leading, spacing: 8) {
+                                                OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
+                                                    selectedLanguage = "es"
                                                 }
-                                            },
-                                            label: {
-                                                Text("languages")
-                                                    .font(.body)
-                                                    .foregroundColor(.fourthColor)
+
+                                                OptionButton(label: "English 🇺🇸", isSelected: selectedLanguage == "en") {
+                                                    selectedLanguage = "en"
+                                                }
+
+                                                OptionButton(label: "Français 🇫🇷", isSelected: selectedLanguage == "fr") {
+                                                    selectedLanguage = "fr"
+                                                }
+
+                                                OptionButton(label: "Deutsch 🇩🇪", isSelected: selectedLanguage == "de") {
+                                                    selectedLanguage = "de"
+                                                }
+
+                                                OptionButton(label: "Italiano 🇮🇹", isSelected: selectedLanguage == "it") {
+                                                    selectedLanguage = "it"
+                                                }
+
+                                                OptionButton(label: "日本語 🇯🇵", isSelected: selectedLanguage == "ja") {
+                                                    selectedLanguage = "ja"
+                                                }
+
+                                                OptionButton(label: "中文 🇨🇳", isSelected: selectedLanguage == "zh") {
+                                                    selectedLanguage = "zh"
+                                                }
                                             }
-                                        )
+                                        }
                                     }
 
                                     Spacer()

--- a/NexStock1.0/View/SettingsView.swift
+++ b/NexStock1.0/View/SettingsView.swift
@@ -104,7 +104,7 @@ struct SettingsView: View {
                                             .font(.body)
                                             .foregroundColor(.fourthColor)
 
-                                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))], spacing: 8) {
+                                        VStack(alignment: .leading, spacing: 8) {
                                             OptionButton(label: "Español 🇲🇽", isSelected: selectedLanguage == "es") {
                                                 selectedLanguage = "es"
                                             }


### PR DESCRIPTION
## Summary
- add `OptionButton` reusable view
- update `SettingsView` to use `OptionButton` for appearance and language selection

## Testing
- `swiftc -parse NexStock1.0/View/SettingsView.swift`
- `swiftc -parse NexStock1.0/View/OptionButton.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861a7531c98832792717178045969b4